### PR TITLE
fix: Set serve_from_sub_path to false in Grafana

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 ## [main](https://github.com/aneoconsulting/ArmoniK.Infra/tree/main)
 
+Changed
+-
+
+* From version `10.x` of Grafana, set the parameter `serve_from_sub_path` to `false`.
+
+Breaking changes
+-
+
+* Refactor module of AWS VPC
+* Refactor module of AWS VPC endpoints
+
 ## [0.0.2](https://github.com/aneoconsulting/ArmoniK.Infra/releases/tag/0.0.2) (2023-05-11)
 
 Changed

--- a/monitoring/onpremise/grafana/init-configmap.tf
+++ b/monitoring/onpremise/grafana/init-configmap.tf
@@ -8,7 +8,7 @@ resource "kubernetes_config_map" "grafana_ini" {
     [server]
     domain=localhost
     root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana
-    serve_from_sub_path = true
+    serve_from_sub_path = false
     %{if !var.authentication}
     [auth.anonymous]
     enabled = true


### PR DESCRIPTION
From version `10.x` of Grafana, set the parameter `serve_from_sub_path` to `false`.