### PR TITLE
feat: validity period of activemq and redis

### DIFF
--- a/storage/onpremise/activemq/README.md
+++ b/storage/onpremise/activemq/README.md
@@ -59,7 +59,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_activemq"></a> [activemq](#input\_activemq) | Parameters of ActiveMQ | <pre>object({<br>    image              = string<br>    tag                = string<br>    node_selector      = any<br>    image_pull_secrets = string<br>  })</pre> | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK storage resources | `string` | n/a | yes |
-| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | validity period of the certificate in hours | `string` | `"8760"` | no |
+| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | Validity period of the certificate in hours | `string` | `"8760"` | no |
 
 ## Outputs
 

--- a/storage/onpremise/activemq/README.md
+++ b/storage/onpremise/activemq/README.md
@@ -59,6 +59,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_activemq"></a> [activemq](#input\_activemq) | Parameters of ActiveMQ | <pre>object({<br>    image              = string<br>    tag                = string<br>    node_selector      = any<br>    image_pull_secrets = string<br>  })</pre> | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK storage resources | `string` | n/a | yes |
+| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | validity period of the certificate in hours | `string` | `"8760"` | no |
 
 ## Outputs
 

--- a/storage/onpremise/activemq/certificates.tf
+++ b/storage/onpremise/activemq/certificates.tf
@@ -10,7 +10,7 @@ resource "tls_private_key" "root_activemq" {
 resource "tls_self_signed_cert" "root_activemq" {
   private_key_pem       = tls_private_key.root_activemq.private_key_pem
   is_ca_certificate     = true
-  validity_period_hours = "168"
+  validity_period_hours = var.var.validity_period_hours
   allowed_uses = [
     "cert_signing",
     "key_encipherment",
@@ -46,7 +46,7 @@ resource "tls_locally_signed_cert" "activemq_certificate" {
   ca_private_key_pem = tls_private_key.root_activemq.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.root_activemq.cert_pem
 
-  validity_period_hours = "168"
+  validity_period_hours = var.var.validity_period_hours
 
   allowed_uses = [
     "key_encipherment",

--- a/storage/onpremise/activemq/certificates.tf
+++ b/storage/onpremise/activemq/certificates.tf
@@ -10,7 +10,7 @@ resource "tls_private_key" "root_activemq" {
 resource "tls_self_signed_cert" "root_activemq" {
   private_key_pem       = tls_private_key.root_activemq.private_key_pem
   is_ca_certificate     = true
-  validity_period_hours = var.var.validity_period_hours
+  validity_period_hours = var.validity_period_hours
   allowed_uses = [
     "cert_signing",
     "key_encipherment",
@@ -46,7 +46,7 @@ resource "tls_locally_signed_cert" "activemq_certificate" {
   ca_private_key_pem = tls_private_key.root_activemq.private_key_pem
   ca_cert_pem        = tls_self_signed_cert.root_activemq.cert_pem
 
-  validity_period_hours = var.var.validity_period_hours
+  validity_period_hours = var.validity_period_hours
 
   allowed_uses = [
     "key_encipherment",

--- a/storage/onpremise/activemq/variables.tf
+++ b/storage/onpremise/activemq/variables.tf
@@ -16,7 +16,7 @@ variable "activemq" {
 }
 
 variable "validity_period_hours" {
-  description = "validity period of the certificate in hours"
+  description = "Validity period of the certificate in hours"
   type        = string
   default     = "8760" # 1 year
 }

--- a/storage/onpremise/activemq/variables.tf
+++ b/storage/onpremise/activemq/variables.tf
@@ -14,3 +14,9 @@ variable "activemq" {
     image_pull_secrets = string
   })
 }
+
+variable "validity_period_hours" {
+  description = "validity period of the certificate in hours"
+  type        = string
+  default     = "8760" # 1 year
+}

--- a/storage/onpremise/mongodb/README.md
+++ b/storage/onpremise/mongodb/README.md
@@ -59,7 +59,7 @@ No modules.
 | <a name="input_mongodb"></a> [mongodb](#input\_mongodb) | Parameters of MongoDB | <pre>object({<br>    image              = string<br>    tag                = string<br>    node_selector      = any<br>    image_pull_secrets = string<br>    replicas_number    = number<br>  })</pre> | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK resources | `string` | n/a | yes |
 | <a name="input_persistent_volume"></a> [persistent\_volume](#input\_persistent\_volume) | Persistent volume info | <pre>object({<br>    storage_provisioner = string<br>    parameters          = map(string)<br>    # Resources for PVC<br>    resources = object({<br>      limits = object({<br>        storage = string<br>      })<br>      requests = object({<br>        storage = string<br>      })<br>    })<br>  })</pre> | n/a | yes |
-| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | validity period of the certificate in hours | `string` | `"8760"` | no |
+| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | Validity period of the certificate in hours | `string` | `"8760"` | no |
 
 ## Outputs
 

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -35,7 +35,7 @@ variable "persistent_volume" {
 }
 
 variable "validity_period_hours" {
-  description = "validity period of the certificate in hours"
+  description = "Validity period of the certificate in hours"
   type        = string
   default     = "8760" # 1 year
 }

--- a/storage/onpremise/redis/README.md
+++ b/storage/onpremise/redis/README.md
@@ -46,6 +46,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK storage resources | `string` | n/a | yes |
 | <a name="input_redis"></a> [redis](#input\_redis) | Parameters of Redis | <pre>object({<br>    image              = string<br>    tag                = string<br>    node_selector      = any<br>    image_pull_secrets = string<br>    max_memory         = string<br>  })</pre> | n/a | yes |
+| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | validity period of the certificate in hours | `string` | `"8760"` | no |
 
 ## Outputs
 

--- a/storage/onpremise/redis/README.md
+++ b/storage/onpremise/redis/README.md
@@ -46,7 +46,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK storage resources | `string` | n/a | yes |
 | <a name="input_redis"></a> [redis](#input\_redis) | Parameters of Redis | <pre>object({<br>    image              = string<br>    tag                = string<br>    node_selector      = any<br>    image_pull_secrets = string<br>    max_memory         = string<br>  })</pre> | n/a | yes |
-| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | validity period of the certificate in hours | `string` | `"8760"` | no |
+| <a name="input_validity_period_hours"></a> [validity\_period\_hours](#input\_validity\_period\_hours) | Validity period of the certificate in hours | `string` | `"8760"` | no |
 
 ## Outputs
 

--- a/storage/onpremise/redis/certificates.tf
+++ b/storage/onpremise/redis/certificates.tf
@@ -10,7 +10,7 @@ resource "tls_private_key" "root_redis" {
 resource "tls_self_signed_cert" "root_redis" {
   private_key_pem       = tls_private_key.root_redis.private_key_pem
   is_ca_certificate     = true
-  validity_period_hours = "168"
+  validity_period_hours = var.var.validity_period_hours
   allowed_uses = [
     "cert_signing",
     "key_encipherment",
@@ -45,7 +45,7 @@ resource "tls_locally_signed_cert" "redis_certificate" {
   cert_request_pem      = tls_cert_request.redis_cert_request.cert_request_pem
   ca_private_key_pem    = tls_private_key.root_redis.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.root_redis.cert_pem
-  validity_period_hours = "168"
+  validity_period_hours = var.var.validity_period_hours
   allowed_uses = [
     "key_encipherment",
     "digital_signature",

--- a/storage/onpremise/redis/certificates.tf
+++ b/storage/onpremise/redis/certificates.tf
@@ -10,7 +10,7 @@ resource "tls_private_key" "root_redis" {
 resource "tls_self_signed_cert" "root_redis" {
   private_key_pem       = tls_private_key.root_redis.private_key_pem
   is_ca_certificate     = true
-  validity_period_hours = var.var.validity_period_hours
+  validity_period_hours = var.validity_period_hours
   allowed_uses = [
     "cert_signing",
     "key_encipherment",
@@ -45,7 +45,7 @@ resource "tls_locally_signed_cert" "redis_certificate" {
   cert_request_pem      = tls_cert_request.redis_cert_request.cert_request_pem
   ca_private_key_pem    = tls_private_key.root_redis.private_key_pem
   ca_cert_pem           = tls_self_signed_cert.root_redis.cert_pem
-  validity_period_hours = var.var.validity_period_hours
+  validity_period_hours = var.validity_period_hours
   allowed_uses = [
     "key_encipherment",
     "digital_signature",

--- a/storage/onpremise/redis/variables.tf
+++ b/storage/onpremise/redis/variables.tf
@@ -17,7 +17,7 @@ variable "redis" {
 }
 
 variable "validity_period_hours" {
-  description = "validity period of the certificate in hours"
+  description = "Validity period of the certificate in hours"
   type        = string
   default     = "8760" # 1 year
 }

--- a/storage/onpremise/redis/variables.tf
+++ b/storage/onpremise/redis/variables.tf
@@ -19,5 +19,5 @@ variable "redis" {
 variable "validity_period_hours" {
   description = "Validity period of the certificate in hours"
   type        = string
-  default     = "8760" # 1 year
+  default     = "8760" # 1 year 
 }

--- a/storage/onpremise/redis/variables.tf
+++ b/storage/onpremise/redis/variables.tf
@@ -15,3 +15,9 @@ variable "redis" {
     max_memory         = string
   })
 }
+
+variable "validity_period_hours" {
+  description = "validity period of the certificate in hours"
+  type        = string
+  default     = "8760" # 1 year
+}

--- a/storage/onpremise/redis/variables.tf
+++ b/storage/onpremise/redis/variables.tf
@@ -19,5 +19,5 @@ variable "redis" {
 variable "validity_period_hours" {
   description = "Validity period of the certificate in hours"
   type        = string
-  default     = "8760" # 1 year 
+  default     = "8760" # 1 year
 }


### PR DESCRIPTION
mongo DB validity certificate is now configurable with this [PR](https://github.com/aneoconsulting/ArmoniK.Infra/pull/50)
now I did the  for activeMQ and Redis

validity of certificates was hardcoded to 7 days
=> on prem install will not work anymore after 7 days
fix is :
1 - validity is now 1 year by default
2 - it is now overridable by a parameter : 'validity_period_hours'
both configuration available for modules Redis and activeMQ in storage/onpremise folder