### PR TITLE
feat: redis maxmemory samples option

### DIFF
--- a/armonik/admin-0-8-gui.tf
+++ b/armonik/admin-0-8-gui.tf
@@ -6,7 +6,7 @@ resource "kubernetes_deployment" "admin_0_8_gui" {
     namespace = var.namespace
     labels = {
       app     = "armonik"
-      service = "app-gui"
+      service = "admin-0-8-gui"
     }
   }
   spec {

--- a/armonik/admin-0-8-gui.tf
+++ b/armonik/admin-0-8-gui.tf
@@ -1,37 +1,37 @@
 # Control plane deployment
-resource "kubernetes_deployment" "admin_old_gui" {
-  count = var.admin_old_gui != null ? 1 : 0
+resource "kubernetes_deployment" "admin_0_8_gui" {
+  count = var.admin_0_8_gui != null ? 1 : 0
   metadata {
-    name      = "admin-old-gui"
+    name      = "admin-0-8-gui"
     namespace = var.namespace
     labels = {
       app     = "armonik"
-      service = "admin-old-gui"
+      service = "app-gui"
     }
   }
   spec {
-    replicas = var.admin_old_gui.replicas
+    replicas = var.admin_0_8_gui.replicas
     selector {
       match_labels = {
         app     = "armonik"
-        service = "admin-old-gui"
+        service = "admin-0-8-gui"
       }
     }
     template {
       metadata {
-        name      = "admin-old-gui"
+        name      = "admin-0-8-gui"
         namespace = var.namespace
         labels = {
           app     = "armonik"
-          service = "admin-old-gui"
+          service = "admin-0-8-gui"
         }
       }
       spec {
         dynamic "toleration" {
-          for_each = (local.admin_gui_node_selector != {} ? [
-            for index in range(0, length(local.admin_gui_node_selector_keys)) : {
-              key   = local.admin_gui_node_selector_keys[index]
-              value = local.admin_gui_node_selector_values[index]
+          for_each = (local.admin_0_8_gui_node_selector != {} ? [
+            for index in range(0, length(local.admin_0_8_gui_node_selector_keys)) : {
+              key   = local.admin_0_8_gui_node_selector_keys[index]
+              value = local.admin_0_8_gui_node_selector_values[index]
             }
           ] : [])
           content {
@@ -42,20 +42,20 @@ resource "kubernetes_deployment" "admin_old_gui" {
           }
         }
         dynamic "image_pull_secrets" {
-          for_each = (var.admin_old_gui.image_pull_secrets != "" ? [1] : [])
+          for_each = (var.admin_0_8_gui.image_pull_secrets != "" ? [1] : [])
           content {
-            name = var.admin_old_gui.image_pull_secrets
+            name = var.admin_0_8_gui.image_pull_secrets
           }
         }
         restart_policy = "Always" # Always, OnFailure, Never
-        # API container, only needed for old GUI
+        # API container, only needed for 0_8 GUI
         container {
-          name              = var.admin_old_gui.api.name
-          image             = var.admin_old_gui.api.tag != "" ? "${var.admin_old_gui.api.image}:${var.admin_old_gui.api.tag}" : var.admin_old_gui.api.image
-          image_pull_policy = var.admin_old_gui.image_pull_policy
+          name              = var.admin_0_8_gui.api.name
+          image             = var.admin_0_8_gui.api.tag != "" ? "${var.admin_0_8_gui.api.image}:${var.admin_0_8_gui.api.tag}" : var.admin_0_8_gui.api.image
+          image_pull_policy = var.admin_0_8_gui.image_pull_policy
           resources {
-            limits   = var.admin_old_gui.api.limits
-            requests = var.admin_old_gui.api.requests
+            limits   = var.admin_0_8_gui.api.limits
+            requests = var.admin_0_8_gui.api.requests
           }
           port {
             name           = "api-port"
@@ -106,17 +106,17 @@ resource "kubernetes_deployment" "admin_old_gui" {
             }
           }
         }
-        # Old GUI container
+        # 0_8 GUI container
         container {
-          name              = var.admin_old_gui.old.name
-          image             = var.admin_old_gui.old.tag != "" ? "${var.admin_old_gui.old.image}:${var.admin_old_gui.old.tag}" : var.admin_old_gui.old.image
-          image_pull_policy = var.admin_old_gui.image_pull_policy
+          name              = var.admin_0_8_gui.app.name
+          image             = var.admin_0_8_gui.app.tag != "" ? "${var.admin_0_8_gui.app.image}:${var.admin_0_8_gui.app.tag}" : var.admin_0_8_gui.app.image
+          image_pull_policy = var.admin_0_8_gui.image_pull_policy
           resources {
-            limits   = var.admin_old_gui.old.limits
-            requests = var.admin_old_gui.old.requests
+            limits   = var.admin_0_8_gui.app.limits
+            requests = var.admin_0_8_gui.app.requests
           }
           port {
-            name           = "old-port"
+            name           = "app-port"
             container_port = 1080
           }
           env_from {
@@ -180,33 +180,33 @@ resource "kubernetes_deployment" "admin_old_gui" {
   }
 }
 
-# Admin old GUI service
-resource "kubernetes_service" "admin_old_gui" {
-  count = length(kubernetes_deployment.admin_old_gui)
+# Admin 0_8 GUI service
+resource "kubernetes_service" "admin_0_8_gui" {
+  count = length(kubernetes_deployment.admin_0_8_gui)
   metadata {
-    name      = kubernetes_deployment.admin_old_gui[0].metadata.0.name
-    namespace = kubernetes_deployment.admin_old_gui[0].metadata.0.namespace
+    name      = kubernetes_deployment.admin_0_8_gui[0].metadata.0.name
+    namespace = kubernetes_deployment.admin_0_8_gui[0].metadata.0.namespace
     labels = {
-      app     = kubernetes_deployment.admin_old_gui[0].metadata.0.labels.app
-      service = kubernetes_deployment.admin_old_gui[0].metadata.0.labels.service
+      app     = kubernetes_deployment.admin_0_8_gui[0].metadata.0.labels.app
+      service = kubernetes_deployment.admin_0_8_gui[0].metadata.0.labels.service
     }
   }
   spec {
-    type = var.admin_old_gui.service_type
+    type = var.admin_0_8_gui.service_type
     selector = {
-      app     = kubernetes_deployment.admin_old_gui[0].metadata.0.labels.app
-      service = kubernetes_deployment.admin_old_gui[0].metadata.0.labels.service
+      app     = kubernetes_deployment.admin_0_8_gui[0].metadata.0.labels.app
+      service = kubernetes_deployment.admin_0_8_gui[0].metadata.0.labels.service
     }
     port {
-      name        = kubernetes_deployment.admin_old_gui[0].spec.0.template.0.spec.0.container.0.port.0.name
-      port        = var.admin_old_gui.api.port
-      target_port = kubernetes_deployment.admin_old_gui[0].spec.0.template.0.spec.0.container.0.port.0.container_port
+      name        = kubernetes_deployment.admin_0_8_gui[0].spec.0.template.0.spec.0.container.0.port.0.name
+      port        = var.admin_0_8_gui.api.port
+      target_port = kubernetes_deployment.admin_0_8_gui[0].spec.0.template.0.spec.0.container.0.port.0.container_port
       protocol    = "TCP"
     }
     port {
-      name        = kubernetes_deployment.admin_old_gui[0].spec.0.template.0.spec.0.container.1.port.0.name
-      port        = var.admin_old_gui.old.port
-      target_port = kubernetes_deployment.admin_old_gui[0].spec.0.template.0.spec.0.container.1.port.0.container_port
+      name        = kubernetes_deployment.admin_0_8_gui[0].spec.0.template.0.spec.0.container.1.port.0.name
+      port        = var.admin_0_8_gui.app.port
+      target_port = kubernetes_deployment.admin_0_8_gui[0].spec.0.template.0.spec.0.container.1.port.0.container_port
       protocol    = "TCP"
     }
   }

--- a/armonik/admin-0-9-gui.tf
+++ b/armonik/admin-0-9-gui.tf
@@ -1,0 +1,152 @@
+# Control plane deployment
+resource "kubernetes_deployment" "admin_0_9_gui" {
+  count = var.admin_0_9_gui != null ? 1 : 0
+  metadata {
+    name      = "admin-0-9-gui"
+    namespace = var.namespace
+    labels = {
+      app     = "armonik"
+      service = "admin-0-9-gui"
+    }
+  }
+  spec {
+    replicas = var.admin_0_9_gui.replicas
+    selector {
+      match_labels = {
+        app     = "armonik"
+        service = "admin-0-9-gui"
+      }
+    }
+    template {
+      metadata {
+        name      = "admin-0-9-gui"
+        namespace = var.namespace
+        labels = {
+          app     = "armonik"
+          service = "admin-0-9-gui"
+        }
+      }
+      spec {
+        dynamic "toleration" {
+          for_each = (local.admin_0_9_gui_node_selector != {} ? [
+            for index in range(0, length(local.admin_0_9_gui_node_selector_keys)) : {
+              key   = local.admin_0_9_gui_node_selector_keys[index]
+              value = local.admin_0_9_gui_node_selector_values[index]
+            }
+          ] : [])
+          content {
+            key      = toleration.value.key
+            operator = "Equal"
+            value    = toleration.value.value
+            effect   = "NoSchedule"
+          }
+        }
+        dynamic "image_pull_secrets" {
+          for_each = (var.admin_0_9_gui.image_pull_secrets != "" ? [1] : [])
+          content {
+            name = var.admin_0_9_gui.image_pull_secrets
+          }
+        }
+        restart_policy = "Always" # Always, OnFailure, Never
+        # App container
+        container {
+          name              = var.admin_0_9_gui.name
+          image             = var.admin_0_9_gui.tag != "" ? "${var.admin_0_9_gui.image}:${var.admin_0_9_gui.tag}" : var.admin_0_9_gui.image
+          image_pull_policy = var.admin_0_9_gui.image_pull_policy
+          resources {
+            limits   = var.admin_0_9_gui.limits
+            requests = var.admin_0_9_gui.requests
+          }
+          port {
+            name           = "app-port"
+            container_port = 1080
+          }
+          env_from {
+            config_map_ref {
+              name = kubernetes_config_map.core_config.metadata[0].name
+            }
+          }
+          env {
+            name  = "ControlPlane__Endpoint"
+            value = local.control_plane_url
+          }
+          dynamic "env" {
+            for_each = (data.kubernetes_secret.grafana.data.enabled != "" ? [1] : [])
+            content {
+              name  = "Grafana__Endpoint"
+              value = data.kubernetes_secret.grafana.data.url
+            }
+          }
+          dynamic "env" {
+            for_each = (data.kubernetes_secret.seq.data.enabled ? [1] : [])
+            content {
+              name  = "Seq__Endpoint"
+              value = data.kubernetes_secret.seq.data.web_url
+            }
+          }
+          dynamic "env" {
+            for_each = local.credentials
+            content {
+              name = env.key
+              value_from {
+                secret_key_ref {
+                  key      = env.value.key
+                  name     = env.value.name
+                  optional = false
+                }
+              }
+            }
+          }
+          dynamic "volume_mount" {
+            for_each = local.certificates
+            content {
+              name       = volume_mount.value.name
+              mount_path = volume_mount.value.mount_path
+              read_only  = true
+            }
+          }
+        }
+        # Secrets volumes
+        dynamic "volume" {
+          for_each = local.certificates
+          content {
+            name = volume.value.name
+            secret {
+              secret_name = volume.value.secret_name
+              optional    = false
+            }
+          }
+        }
+      }
+    }
+  }
+}
+
+# Admin GUI service
+resource "kubernetes_service" "admin_0_9_gui" {
+  count = length(kubernetes_deployment.admin_0_9_gui)
+  metadata {
+    name      = kubernetes_deployment.admin_0_9_gui[0].metadata.0.name
+    namespace = kubernetes_deployment.admin_0_9_gui[0].metadata.0.namespace
+    labels = {
+      app     = kubernetes_deployment.admin_0_9_gui[0].metadata.0.labels.app
+      service = kubernetes_deployment.admin_0_9_gui[0].metadata.0.labels.service
+    }
+  }
+  spec {
+    type = var.admin_0_9_gui.service_type
+    selector = {
+      app     = kubernetes_deployment.admin_0_9_gui[0].metadata.0.labels.app
+      service = kubernetes_deployment.admin_0_9_gui[0].metadata.0.labels.service
+    }
+    port {
+      name        = kubernetes_deployment.admin_0_9_gui[0].spec.0.template.0.spec.0.container.0.port.0.name
+      port        = var.admin_0_9_gui.port
+      target_port = kubernetes_deployment.admin_0_9_gui[0].spec.0.template.0.spec.0.container.0.port.0.container_port
+      protocol    = "TCP"
+    }
+  }
+  timeouts {
+    create = "2m"
+  }
+}

--- a/armonik/external-data.tf
+++ b/armonik/external-data.tf
@@ -94,7 +94,7 @@ locals {
   # Deprecated, must be removed in a future version
   admin_0_8_url = length(kubernetes_service.admin_0_8_gui) > 0 ? "http://${local.admin_0_8_gui_endpoints.ip}:${local.admin_0_8_gui_endpoints.app_port}/" : null
   # Deprecated, must be removed in a future version
-  admin_0_9_url    = length(kubernetes_service.admin_0_9_gui) > 0 ? "http://${local.admin_0_9_gui_endpoints.ip}:${local.admin_0_9_gui_endpoints.app_port}/" : null
+  admin_0_9_url    = length(kubernetes_service.admin_0_9_gui) > 0 ? "http://${local.admin_0_9_gui_endpoints.ip}:${local.admin_0_9_gui_endpoints.app_port}" : null
   ingress_http_url = var.ingress != null ? "${var.ingress.tls ? "https" : "http"}://${local.ingress_endpoint.ip}:${local.ingress_endpoint.http_port}" : ""
   ingress_grpc_url = var.ingress != null ? "${var.ingress.tls ? "https" : "http"}://${local.ingress_endpoint.ip}:${local.ingress_endpoint.grpc_port}" : ""
 }

--- a/armonik/external-data.tf
+++ b/armonik/external-data.tf
@@ -31,24 +31,40 @@ locals {
     app_port = local.admin_gui_load_balancer.app_port
   }) : null
 
-  admin_old_gui_load_balancer = length(kubernetes_service.admin_old_gui) > 0 ? (kubernetes_service.admin_old_gui[0].spec.0.type == "LoadBalancer" ? {
-    ip       = (kubernetes_service.admin_old_gui[0].status.0.load_balancer.0.ingress.0.ip == "" ? kubernetes_service.admin_old_gui[0].status.0.load_balancer.0.ingress.0.hostname : kubernetes_service.admin_old_gui[0].status.0.load_balancer.0.ingress.0.ip)
-    api_port = kubernetes_service.admin_old_gui[0].spec.0.port.0.port
-    app_port = kubernetes_service.admin_old_gui[0].spec.0.port.1.port
+  admin_0_9_gui_load_balancer = length(kubernetes_service.admin_0_9_gui) > 0 ? (kubernetes_service.admin_0_9_gui[0].spec.0.type == "LoadBalancer" ? {
+    ip       = (kubernetes_service.admin_0_9_gui[0].status.0.load_balancer.0.ingress.0.ip == "" ? kubernetes_service.admin_0_9_gui[0].status.0.load_balancer.0.ingress.0.hostname : kubernetes_service.admin_0_9_gui[0].status.0.load_balancer.0.ingress.0.ip)
+    app_port = kubernetes_service.admin_0_9_gui[0].spec.0.port.0.port
+    } : {
+    ip       = ""
+    app_port = ""
+  }) : null
+
+  admin_0_9_gui_endpoints = length(kubernetes_service.admin_0_9_gui) > 0 ? (local.admin_0_9_gui_load_balancer.ip == "" && kubernetes_service.admin_0_9_gui[0].spec.0.type == "ClusterIP" ? {
+    ip       = kubernetes_service.admin_0_9_gui[0].spec.0.cluster_ip
+    app_port = kubernetes_service.admin_0_9_gui[0].spec.0.port.0.port
+    } : {
+    ip       = local.admin_0_9_gui_load_balancer.ip
+    app_port = local.admin_0_9_gui_load_balancer.app_port
+  }) : null
+
+  admin_0_8_gui_load_balancer = length(kubernetes_service.admin_0_8_gui) > 0 ? (kubernetes_service.admin_0_8_gui[0].spec.0.type == "LoadBalancer" ? {
+    ip       = (kubernetes_service.admin_0_8_gui[0].status.0.load_balancer.0.ingress.0.ip == "" ? kubernetes_service.admin_0_8_gui[0].status.0.load_balancer.0.ingress.0.hostname : kubernetes_service.admin_0_8_gui[0].status.0.load_balancer.0.ingress.0.ip)
+    api_port = kubernetes_service.admin_0_8_gui[0].spec.0.port.0.port
+    app_port = kubernetes_service.admin_0_8_gui[0].spec.0.port.1.port
     } : {
     ip       = ""
     api_port = ""
     app_port = ""
   }) : null
 
-  admin_old_gui_endpoints = length(kubernetes_service.admin_old_gui) > 0 ? (local.admin_old_gui_load_balancer.ip == "" && kubernetes_service.admin_old_gui[0].spec.0.type == "ClusterIP" ? {
-    ip       = kubernetes_service.admin_old_gui[0].spec.0.cluster_ip
-    api_port = kubernetes_service.admin_old_gui[0].spec.0.port.0.port
-    app_port = kubernetes_service.admin_old_gui[0].spec.0.port.1.port
+  admin_0_8_gui_endpoints = length(kubernetes_service.admin_0_8_gui) > 0 ? (local.admin_0_8_gui_load_balancer.ip == "" && kubernetes_service.admin_0_8_gui[0].spec.0.type == "ClusterIP" ? {
+    ip       = kubernetes_service.admin_0_8_gui[0].spec.0.cluster_ip
+    api_port = kubernetes_service.admin_0_8_gui[0].spec.0.port.0.port
+    app_port = kubernetes_service.admin_0_8_gui[0].spec.0.port.1.port
     } : {
-    ip       = local.admin_old_gui_load_balancer.ip
-    api_port = local.admin_old_gui_load_balancer.api_port
-    app_port = local.admin_old_gui_load_balancer.app_port
+    ip       = local.admin_0_8_gui_load_balancer.ip
+    api_port = local.admin_0_8_gui_load_balancer.api_port
+    app_port = local.admin_0_8_gui_load_balancer.app_port
   }) : null
 
   ingress_load_balancer = (var.ingress != null ? kubernetes_service.ingress.0.spec.0.type == "LoadBalancer" : false) ? {
@@ -73,8 +89,12 @@ locals {
 
   control_plane_url = "http://${local.control_plane_endpoints.ip}:${local.control_plane_endpoints.port}"
   admin_app_url     = length(kubernetes_service.admin_gui) > 0 ? "http://${local.admin_gui_endpoints.ip}:${local.admin_gui_endpoints.app_port}" : null
-  admin_api_url     = length(kubernetes_service.admin_old_gui) > 0 ? "http://${local.admin_old_gui_endpoints.ip}:${local.admin_old_gui_endpoints.api_port}/api" : null
-  admin_old_url     = length(kubernetes_service.admin_old_gui) > 0 ? "http://${local.admin_old_gui_endpoints.ip}:${local.admin_old_gui_endpoints.app_port}/" : null
-  ingress_http_url  = var.ingress != null ? "${var.ingress.tls ? "https" : "http"}://${local.ingress_endpoint.ip}:${local.ingress_endpoint.http_port}" : ""
-  ingress_grpc_url  = var.ingress != null ? "${var.ingress.tls ? "https" : "http"}://${local.ingress_endpoint.ip}:${local.ingress_endpoint.grpc_port}" : ""
+  # Deprecated, must be removed in a future version
+  admin_api_url = length(kubernetes_service.admin_0_8_gui) > 0 ? "http://${local.admin_0_8_gui_endpoints.ip}:${local.admin_0_8_gui_endpoints.api_port}/api" : null
+  # Deprecated, must be removed in a future version
+  admin_0_8_url = length(kubernetes_service.admin_0_8_gui) > 0 ? "http://${local.admin_0_8_gui_endpoints.ip}:${local.admin_0_8_gui_endpoints.app_port}/" : null
+  # Deprecated, must be removed in a future version
+  admin_0_9_url    = length(kubernetes_service.admin_0_9_gui) > 0 ? "http://${local.admin_0_9_gui_endpoints.ip}:${local.admin_0_9_gui_endpoints.app_port}/" : null
+  ingress_http_url = var.ingress != null ? "${var.ingress.tls ? "https" : "http"}://${local.ingress_endpoint.ip}:${local.ingress_endpoint.http_port}" : ""
+  ingress_grpc_url = var.ingress != null ? "${var.ingress.tls ? "https" : "http"}://${local.ingress_endpoint.ip}:${local.ingress_endpoint.grpc_port}" : ""
 }

--- a/armonik/ingress-configmap.tf
+++ b/armonik/ingress-configmap.tf
@@ -64,16 +64,43 @@ server {
     location = /admin/fr {
         rewrite ^ $scheme://$http_host/admin/fr/;
     }
+    # Deprecated, must be removed in a new version. Keeped for retrocompatibility
     location = /old-admin {
-        rewrite ^ $scheme://$http_host/old-admin/ permanent;
+        rewrite ^ $scheme://$http_host/admin-0.8/ permanent;
+    }
+    # Deprecated, must be removed in a new version
+    location = /admin-0.8 {
+        rewrite ^ $scheme://$http_host/admin-0.8/ permanent;
+    }
+    # Deprecated, must be removed in a new version
+    location = /admin-0.9 {
+        rewrite ^ $scheme://$http_host/admin-0.9/$accept_language/;
+    }
+    # Deprecated, must be removed in a new version
+    location = /admin-0.9/ {
+        rewrite ^ $scheme://$http_host/admin-0.9/$accept_language/;
+    }
+    # Deprecated, must be removed in a new version
+    location = /admin-0.9/en {
+        rewrite ^ $scheme://$http_host/admin-0.9/en/;
+    }
+    # Deprecated, must be removed in a new version
+    location = /admin-0.9/fr {
+        rewrite ^ $scheme://$http_host/admin-0.9/fr/;
     }
 %{if var.admin_gui != null~}
     location /admin/ {
         proxy_pass ${local.admin_app_url};
     }
-    location /old-admin/ {
-        proxy_pass ${local.admin_old_url};
+    # Deprecated, must be removed in a new version
+    location /admin-0.8/ {
+        proxy_pass ${local.admin_0_8_url};
     }
+    # Deprecated, must be removed in a new version
+    location /admin-0.9/ {
+      proxy_pass ${local.admin_0_9_url};
+    }
+    # Deprecated, must be removed in a new version
     location /api {
         proxy_pass ${local.admin_api_url};
     }

--- a/armonik/ingress-configmap.tf
+++ b/armonik/ingress-configmap.tf
@@ -98,6 +98,10 @@ server {
         grpc_send_timeout 1d;
     }
 
+    location /static/ {
+        alias /static/;
+    }
+
 
    proxy_buffering off;
    proxy_request_buffering off;
@@ -207,6 +211,17 @@ resource "kubernetes_config_map" "ingress" {
   }
   data = {
     "armonik.conf" = local.armonik_conf
+  }
+}
+
+resource "kubernetes_config_map" "static" {
+  count = (var.ingress != null ? 1 : 0)
+  metadata {
+    name      = "ingress-nginx-static"
+    namespace = var.namespace
+  }
+  data = {
+    "environment.json" = jsonencode(var.environment_description)
   }
 }
 

--- a/armonik/ingress.tf
+++ b/armonik/ingress.tf
@@ -88,6 +88,11 @@ resource "kubernetes_deployment" "ingress" {
             mount_path = "/etc/nginx/conf.d"
             read_only  = true
           }
+          volume_mount {
+            name       = "static"
+            mount_path = "/static"
+            read_only  = true
+          }
         }
         volume {
           name = "ingress-secret-volume"
@@ -107,6 +112,13 @@ resource "kubernetes_deployment" "ingress" {
           name = "ingress-nginx"
           config_map {
             name     = kubernetes_config_map.ingress.0.metadata[0].name
+            optional = false
+          }
+        }
+        volume {
+          name = "static"
+          config_map {
+            name     = kubernetes_config_map.static.0.metadata[0].name
             optional = false
           }
         }

--- a/armonik/locals.tf
+++ b/armonik/locals.tf
@@ -18,6 +18,16 @@ locals {
   admin_gui_node_selector_keys   = keys(local.admin_gui_node_selector)
   admin_gui_node_selector_values = values(local.admin_gui_node_selector)
 
+  # Node selector for admin GUI 0.9
+  admin_0_9_gui_node_selector        = try(var.admin_0_9_gui.node_selector, {})
+  admin_0_9_gui_node_selector_keys   = keys(local.admin_0_9_gui_node_selector)
+  admin_0_9_gui_node_selector_values = values(local.admin_0_9_gui_node_selector)
+
+  # Node selector for admin GUI 0.8
+  admin_0_8_gui_node_selector        = try(var.admin_0_8_gui.node_selector, {})
+  admin_0_8_gui_node_selector_keys   = keys(local.admin_0_8_gui_node_selector)
+  admin_0_8_gui_node_selector_values = values(local.admin_0_8_gui_node_selector)
+
   # Node selector for compute plane
   compute_plane_node_selector        = { for partition, compute_plane in var.compute_plane : partition => try(compute_plane.node_selector, {}) }
   compute_plane_node_selector_keys   = { for partition in local.partition_names : partition => keys(local.compute_plane_node_selector[partition]) }

--- a/armonik/outputs.tf
+++ b/armonik/outputs.tf
@@ -4,15 +4,17 @@ output "endpoint_urls" {
     grafana_url       = data.kubernetes_secret.grafana.data.enabled ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/grafana/" : nonsensitive(data.kubernetes_secret.grafana.data.url)) : ""
     seq_web_url       = data.kubernetes_secret.seq.data.enabled ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/seq/" : nonsensitive(data.kubernetes_secret.seq.data.web_url)) : ""
     admin_app_url     = length(kubernetes_service.admin_gui) > 0 ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/admin" : local.admin_app_url) : null
-    admin_api_url     = length(kubernetes_service.admin_old_gui) > 0 ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/api" : local.admin_api_url) : null
-    admin_old_url     = length(kubernetes_service.admin_old_gui) > 0 ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/old-admin" : local.admin_old_url) : null
+    admin_api_url     = length(kubernetes_service.admin_0_8_gui) > 0 ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/api" : local.admin_api_url) : null
+    admin_0_8_url     = length(kubernetes_service.admin_0_8_gui) > 0 ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/admin-0.8" : local.admin_0_8_url) : null
+    admin_0_9_url     = length(kubernetes_service.admin_0_9_gui) > 0 ? (local.ingress_http_url != "" ? "${local.ingress_http_url}/admin-0.9" : local.admin_0_9_url) : null
     } : {
     control_plane_url = local.control_plane_url
     grafana_url       = nonsensitive(data.kubernetes_secret.grafana.data.url)
     seq_web_url       = nonsensitive(data.kubernetes_secret.seq.data.web_url)
     admin_app_url     = local.admin_app_url
     admin_api_url     = local.admin_api_url
-    admin_old_url     = local.admin_old_url
+    admin_0_8_url     = local.admin_0_8_url
+    admin_0_9_url     = local.admin_0_9_url
   }
 }
 

--- a/armonik/variables.tf
+++ b/armonik/variables.tf
@@ -355,3 +355,9 @@ variable "metrics_server_chart_name" {
   type        = string
   default     = "metrics-server"
 }
+
+variable "environment_description" {
+  description = "Description of the environment deployed"
+  type        = any
+  default     = null
+}

--- a/armonik/variables.tf
+++ b/armonik/variables.tf
@@ -164,9 +164,10 @@ variable "admin_gui" {
   default = null
 }
 
-# Parameters of old admin gui
-variable "admin_old_gui" {
-  description = "Parameters of the old admin GUI"
+# Deprecated, must be removed in a future version
+# Parameters of admin gui v0.8 (previously called old admin gui)
+variable "admin_0_8_gui" {
+  description = "Parameters of the admin GUI v0.8"
   type = object({
     api = object({
       name  = string
@@ -182,7 +183,7 @@ variable "admin_old_gui" {
         memory = string
       })
     })
-    old = object({
+    app = object({
       name  = string
       image = string
       tag   = string
@@ -195,6 +196,32 @@ variable "admin_old_gui" {
         cpu    = string
         memory = string
       })
+    })
+    service_type       = string
+    replicas           = number
+    image_pull_policy  = string
+    image_pull_secrets = string
+    node_selector      = any
+  })
+  default = null
+}
+
+# Deprecated, must be removed in a future version
+# Parameters of admin gui v0.9
+variable "admin_0_9_gui" {
+  description = "Parameters of the admin GUI v0.9"
+  type = object({
+    name  = string
+    image = string
+    tag   = string
+    port  = number
+    limits = object({
+      cpu    = string
+      memory = string
+    })
+    requests = object({
+      cpu    = string
+      memory = string
     })
     service_type       = string
     replicas           = number

--- a/monitoring/onpremise/grafana/init-configmap.tf
+++ b/monitoring/onpremise/grafana/init-configmap.tf
@@ -8,7 +8,7 @@ resource "kubernetes_config_map" "grafana_ini" {
     [server]
     domain=localhost
     root_url = %(protocol)s://%(domain)s:%(http_port)s/grafana
-    serve_from_sub_path = true
+    serve_from_sub_path = false
     %{if !var.authentication}
     [auth.anonymous]
     enabled = true

--- a/storage/aws/elasticache/elasticache.tf
+++ b/storage/aws/elasticache/elasticache.tf
@@ -44,6 +44,14 @@ resource "aws_elasticache_parameter_group" "elasticache" {
     name  = "maxmemory-policy"
     value = "allkeys-lru"
   }
+
+  dynamic "parameter" {
+   for_each = var.elasticache.max_memory_samples == "" ? [] : [1]
+   content {
+     name = "maxmemory-samples"
+     value = var.elasticache.max_memory_samples
+   }
+  }
   tags = local.tags
 }
 

--- a/storage/aws/elasticache/variables.tf
+++ b/storage/aws/elasticache/variables.tf
@@ -36,6 +36,7 @@ variable "elasticache" {
     preferred_cache_cluster_azs = list(string)
     data_tiering_enabled        = bool
     log_retention_in_days       = number
+    max_memory_samples          = string
     cloudwatch_log_groups = object({
       slow_log   = string
       engine_log = string

--- a/storage/onpremise/redis/redis.tf
+++ b/storage/onpremise/redis/redis.tf
@@ -54,7 +54,7 @@ resource "kubernetes_deployment" "redis" {
           image             = "${var.redis.image}:${var.redis.tag}"
           image_pull_policy = "IfNotPresent"
           command           = ["redis-server"]
-          args = [
+          args = compact([
             "--tls-port 6379",
             "--port 0",
             "--tls-cert-file /certificates/cert.pem",
@@ -62,8 +62,9 @@ resource "kubernetes_deployment" "redis" {
             "--tls-auth-clients no",
             "--requirepass ${random_password.redis_password.result}",
             "--maxmemory ${var.redis.max_memory}",
+            var.redis.max_memory_samples != "" ? "--maxmemory-samples ${var.redis.max_memory_samples}" : null, 
             "--maxmemory-policy allkeys-lru"
-          ]
+          ])
           port {
             container_port = 6379
           }

--- a/storage/onpremise/redis/variables.tf
+++ b/storage/onpremise/redis/variables.tf
@@ -13,6 +13,7 @@ variable "redis" {
     node_selector      = any
     image_pull_secrets = string
     max_memory         = string
+    max_memory_samples = optional(string, "")
   })
 }
 


### PR DESCRIPTION
As described in the official Redis documentation : 
Redis LRU eviction is not a perfect LRU but use sampling : [link](https://redis.io/docs/reference/eviction/#approximated-lru-algorithm)
=> during the eviction process by default batchs of 5 random keys are challenged and the oldest one is removed
=> it can conduct to lose data of our current executing job
depending of the user workload it can be helpful to expose the sampling number in the configuration of redis/elasticache
It will not fix the problem, but it will reduce the frequency of its occurrence.
test validation screenshot on AWS
![image](https://github.com/aneoconsulting/ArmoniK.Infra/assets/113617172/e7ee260c-3381-4479-aae7-f616501d7a88)

tested on AWS+Local - allinone+splitted
