### PR TITLE
fix: fix taint in gke

### DIFF
--- a/kubernetes/gcp/gke/main.tf
+++ b/kubernetes/gcp/gke/main.tf
@@ -21,11 +21,7 @@ locals {
       display_name = "CLUSTER-VPC"
     }
   ] : []))
-  node_pools = var.autopilot ? null : [
-    for node_pool in var.node_pools : merge(node_pool, {
-      name = "${var.name}-${node_pool["name"]}"
-    })
-  ]
+  node_pools = var.autopilot ? null : var.node_pools
   # NOTE: Dataplane-V2 conflicts with the Calico network policy add-on because
   # it provides redundant NetworkPolicy capabilities. If V2 is enabled, the
   # Calico add-on should be disabled.


### PR DESCRIPTION
taints are applied on node
node name for the taint MUST be the same than the name of the nodes
so the code : 
`name = "${var.name}-${node_pool["name"]}"`
was adding name of the cluster before the name of the node
but the user who give the taints in repo armonik don't know it. => a name mismatch will occur and taint will not be applied

after fix :
![image](https://github.com/aneoconsulting/ArmoniK.Infra/assets/113617172/64377596-6d99-40aa-83d8-f86dfadf1917)

