### PR TITLE
fix: adjust prometheus cluster roles to enable pod metrics scraping

### DIFF
--- a/monitoring/onpremise/prometheus/main.tf
+++ b/monitoring/onpremise/prometheus/main.tf
@@ -141,17 +141,12 @@ resource "kubernetes_cluster_role" "prometheus" {
   }
   rule {
     api_groups = [""]
-    resources  = ["namespaces", "pods", "services", "endpoints", "nodes"]
+    resources  = ["namespaces", "pods", "services", "endpoints", "nodes", "nodes/metrics", "nodes/proxy"]
     verbs      = ["get", "list", "watch"]
   }
   rule {
     non_resource_urls = ["/metrics", "/metrics/cadvisor", "/metrics/resource", "/metrics/probes"]
     verbs             = ["get"]
-  }
-  rule {
-    api_groups = ["*"]
-    resources  = ["*"]
-    verbs      = ["get", "list", "watch"]
   }
 }
 

--- a/monitoring/onpremise/prometheus/main.tf
+++ b/monitoring/onpremise/prometheus/main.tf
@@ -149,8 +149,8 @@ resource "kubernetes_cluster_role" "prometheus" {
     verbs             = ["get"]
   }
   rule {
-    api_groups = ["networking.k8s.io"]
-    resources  = ["ingresses"]
+    api_groups = ["*"]
+    resources  = ["*"]
     verbs      = ["get", "list", "watch"]
   }
 }


### PR DESCRIPTION
The current cluster roles rules don't allow scraping of pod metrics.
<img width="960" alt="error-prometheus" src="https://github.com/aneoconsulting/ArmoniK.Infra/assets/158571650/1e789487-8010-47c4-9b06-d9b94ecbbd97">

This fix allows the collection of various metrics such as cpu and memory information 