### PR TITLE
feat: capacity to persist volumes with custom StorageClass for MongoDB Helm chart

### DIFF
--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -92,7 +92,7 @@ resource "helm_release" "mongodb" {
     }
   }
   dynamic "set" {
-    for_each = var.persistent_volume != null ? [1] : []
+    for_each = var.persistent_volume != null && var.persistent_volume.resources.requests.storage != "8Gi" ? [1] : []
     content {
       name  = "persistence.size"
       value = var.persistent_volume.resources.requests.storage

--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -65,7 +65,7 @@ resource "helm_release" "mongodb" {
 
       "persistentVolumeClaimRetentionPolicy" = var.persistent_volume != null ? {
         "enabled"     = "true"
-        "whenDeleted" = "Delete"
+        "whenDeleted" = var.persistent_volume.reclaim_policy
       } : {}
     })
   ]

--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -60,7 +60,7 @@ resource "helm_release" "mongodb" {
         "accessMode"   = var.persistent_volume.access_mode
         "size"         = var.persistent_volume.resources.requests.storage
       } : {
-        "enabled" = "false"
+        "enabled" = false
       }
 
       "persistentVolumeClaimRetentionPolicy" = var.persistent_volume != null ? {

--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -78,7 +78,7 @@ resource "helm_release" "mongodb" {
     }
   }
   dynamic "set" {
-    for_each = var.persistent_volume != null ? [1] : []
+    for_each = var.persistent_volume != null && try(var.persistent_volume.storage_provisioner, "") != "" ? [1] : []
     content {
       name  = "persistence.storageClass"
       value = kubernetes_storage_class.mongodb[0].metadata[0].name

--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -59,8 +59,9 @@ resource "helm_release" "mongodb" {
         "storageClass" = kubernetes_storage_class.mongodb[0].metadata[0].name
         "accessMode"   = var.persistent_volume.access_mode
         "size"         = var.persistent_volume.resources.requests.storage
-      } : {
+        } : {
         "enabled" = false
+        "size"    = var.persistent_volume.resources.requests.storage
       }
 
       "persistentVolumeClaimRetentionPolicy" = var.persistent_volume != null ? {

--- a/storage/onpremise/mongodb/persistent-volume.tf
+++ b/storage/onpremise/mongodb/persistent-volume.tf
@@ -1,4 +1,3 @@
-/* Might be defined one day, for retrocompatibility and modularity concerns
 resource "kubernetes_storage_class" "mongodb" {
   count = var.persistent_volume != null ? 1 : 0
   metadata {
@@ -16,25 +15,24 @@ resource "kubernetes_storage_class" "mongodb" {
   parameters          = var.persistent_volume.parameters
 }
 
-resource "kubernetes_persistent_volume_claim" "mongodb" {
-  count = length(kubernetes_storage_class.mongodb) > 0 ? 1 : 0
-  metadata {
-    name      = "mongodb"
-    namespace = var.namespace
-    labels = {
-      app     = "mongodb"
-      type    = "persistent-volume-claim"
-      service = "persistent-volume"
-    }
-  }
-  spec {
-    access_modes       = var.persistent_volume.access_mode
-    storage_class_name = kubernetes_storage_class.mongodb[0].metadata[0].name
-    resources {
-      requests = var.persistent_volume.resources.requests
-      limits   = var.persistent_volume.resources.limits
-    }
-  }
-  wait_until_bound = var.persistent_volume.wait_until_bound
-}
-*/
+# resource "kubernetes_persistent_volume_claim" "mongodb" {
+#   count = length(kubernetes_storage_class.mongodb) > 0 ? 1 : 0
+#   metadata {
+#     name      = "mongodb"
+#     namespace = var.namespace
+#     labels = {
+#       app     = "mongodb"
+#       type    = "persistent-volume-claim"
+#       service = "persistent-volume"
+#     }
+#   }
+#   spec {
+#     access_modes       = var.persistent_volume.access_mode
+#     storage_class_name = kubernetes_storage_class.mongodb[0].metadata[0].name
+#     resources {
+#       requests = var.persistent_volume.resources.requests
+#       limits   = var.persistent_volume.resources.limits
+#     }
+#   }
+#   wait_until_bound = var.persistent_volume.wait_until_bound
+# }

--- a/storage/onpremise/mongodb/persistent-volume.tf
+++ b/storage/onpremise/mongodb/persistent-volume.tf
@@ -1,5 +1,5 @@
 resource "kubernetes_storage_class" "mongodb" {
-  count = var.persistent_volume != null ? 1 : 0
+  count = var.persistent_volume != null && try(var.persistent_volume.storage_provisioner, "") != "" ? 1 : 0
   metadata {
     name = "mongodb"
     labels = {

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -45,8 +45,8 @@ variable "persistent_volume" {
   type = object({
     access_mode         = optional(list(string), ["ReadWriteMany"])
     reclaim_policy      = optional(string, "Delete")
-    storage_provisioner = optional(string)
-    volume_binding_mode = optional(string)
+    storage_provisioner = optional(string, "")
+    volume_binding_mode = optional(string, "")
     parameters          = optional(map(string), {})
 
     # Resources for PVC
@@ -56,10 +56,10 @@ variable "persistent_volume" {
       }))
       requests = optional(object({
         storage = string
-      }))
+      }), "8Gi")
     }))
 
-    wait_until_bound = optional(bool, true)
+    #wait_until_bound = optional(bool, true)
   })
   default = null
 }

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -64,7 +64,6 @@ variable "persistent_volume" {
   default = null
 }
 
-# Not used yet (there for retrocompatibility reasons)
 variable "security_context" {
   description = "Security context for MongoDB pods"
   type = object({
@@ -72,8 +71,8 @@ variable "security_context" {
     fs_group    = number
   })
   default = {
-    run_as_user = 999
-    fs_group    = 999
+    run_as_user = 1001
+    fs_group    = 1001
   }
 }
 

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -56,8 +56,13 @@ variable "persistent_volume" {
       }))
       requests = optional(object({
         storage = string
-      }), { storage = "8Gi" })
-    }))
+      }))
+    }),
+    {
+      requests = {
+        storage = "8Gi"
+      }
+    })
 
     #wait_until_bound = optional(bool, true)
   })

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -50,14 +50,14 @@ variable "persistent_volume" {
     parameters          = optional(map(string), {})
 
     # Resources for PVC
-    resources = object({
-      limits = object({
+    resources = optional(object({
+      limits = optional(object({
         storage = string
-      })
-      requests = object({
+      }))
+      requests = optional(object({
         storage = string
-      })
-    })
+      }))
+    }))
 
     wait_until_bound = optional(bool, true)
   })

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -55,8 +55,8 @@ variable "persistent_volume" {
         storage = string
       }))
       requests = optional(object({
-        storage = optional(string, "8Gi")
-      }))
+        storage = string
+      }), { storage = "8Gi" })
     }))
 
     #wait_until_bound = optional(bool, true)

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -55,8 +55,8 @@ variable "persistent_volume" {
         storage = string
       }))
       requests = optional(object({
-        storage = string
-      }), "8Gi")
+        storage = optional(string, "8Gi")
+      }))
     }))
 
     #wait_until_bound = optional(bool, true)

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -45,8 +45,8 @@ variable "persistent_volume" {
   type = object({
     access_mode         = optional(list(string), ["ReadWriteMany"])
     reclaim_policy      = optional(string, "Delete")
-    storage_provisioner = string
-    volume_binding_mode = string
+    storage_provisioner = optional(string)
+    volume_binding_mode = optional(string)
     parameters          = optional(map(string), {})
 
     # Resources for PVC
@@ -62,15 +62,6 @@ variable "persistent_volume" {
     wait_until_bound = optional(bool, true)
   })
   default = null
-
-  # For retrocompatibility concerns (AWS deployment), this variable must be null for now
-  validation {
-    condition     = var.persistent_volume == null
-    error_message = <<EOT
-    "For now, 'persistent_volume' variable must be null.
-    Custom persistent volume definition for MongoDB is soon to be implemented"
-    EOT
-  }
 }
 
 # Not used yet (there for retrocompatibility reasons)


### PR DESCRIPTION
This PR kinda fixes the regression introduced by the MongoDB module refactoring with PR https://github.com/aneoconsulting/ArmoniK.Infra/pull/140 .

It gives back to the user the possibility to use custom persistent volume for the table storage by defining a custom storage class with the four following options inside the `persistent_volume ` variable : 
- `storage_provisionner`
- `reclaim_policy`
- `volume_binding_mode`
- `parameters `(extra-parameters actually)

This PR also gives the possibility for the user to use the default values created by Helm by providing the module the value `{}` for the `persistent_volume ` variable.

Finally this PR adds the possibility to disable persistence by giving the `null `value for the `persistent_volume` variable.

**WARNING : Disabling persistence causes data to be lost when a MongoDB pod crashes or when the StatefulSet monitoring the MongoDB pods somehow downscales.**