### PR TITLE
fix: update dummy replace used for dependency

### DIFF
--- a/armonik/external-data.tf
+++ b/armonik/external-data.tf
@@ -2,7 +2,7 @@ data "kubernetes_config_map" "dns" {
   metadata {
     name = "coredns"
     # This dummy regex replace is used to ensure this data source is read *after* Kubernetes is up and running
-    namespace = replace(data.kubernetes_secret.deployed_object_storage.id, "/.*/", "kube-system")
+    namespace = replace(var.namespace, "/.*/", "kube-system")
   }
 }
 


### PR DESCRIPTION
The resource used in the replace (`data.kubernetes_secret.deployed_object_storage`) needs to be removed as part of the refactoring, as there is a read from a secret that is being removed. 
The PR therefore use the namespace for the dependency