### PR TITLE
fix: Kubernetes dependency (cf: #154)

### DIFF
--- a/armonik/external-data.tf
+++ b/armonik/external-data.tf
@@ -1,9 +1,11 @@
 data "kubernetes_config_map" "dns" {
   metadata {
-    name = "coredns"
-    # This dummy regex replace is used to ensure this data source is read *after* Kubernetes is up and running
-    namespace = replace(var.namespace, "/.*/", "kube-system")
+    name      = "coredns"
+    namespace = "kube-system"
   }
+
+  # This dependency ensures this data source is read *after* Kubernetes is up and running
+  depends_on = [kubernetes_config_map.core_config]
 }
 
 module "control_plane_endpoint" {


### PR DESCRIPTION
Implement the proper fix from #154
Even if the implicit dependency is rightfully propagated, the data source is still read during plan because the value is already known. Making it depends on the id of the core configmap ensure the value is *unknown* at plan time.