### PR TITLE
feat: custom resources defintion for mongodb

### DIFF
--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -73,6 +73,8 @@ resource "helm_release" "mongodb" {
         "enabled"     = "true"
         "whenDeleted" = var.persistent_volume.reclaim_policy
       } : {}
+
+      "resources" = var.mongodb_resources
     })
   ]
 

--- a/storage/onpremise/mongodb/variables.tf
+++ b/storage/onpremise/mongodb/variables.tf
@@ -40,6 +40,37 @@ variable "mongodb" {
   })
 }
 
+variable "mongodb_resources" {
+  description = "CPU and Memory limits and requests for MongoDB"
+  type = object({
+    limits = optional(object({
+      cpu    = optional(string, "750m")
+      memory = optional(string, "768Mi")
+      }), {
+      cpu    = "750m"
+      memory = "768Mi"
+    })
+    requests = optional(object({
+      cpu    = optional(string, "500m")
+      memory = optional(string, "512Mi")
+      }), {
+      cpu    = "500m"
+      memory = "512Mi"
+    })
+  })
+  default = {
+    limits = {
+      cpu    = "750m"
+      memory = "768Mi"
+    }
+    requests = {
+      cpu    = "500m"
+      memory = "512Mi"
+    }
+  }
+}
+
+
 variable "persistent_volume" {
   description = "Persistent Volume parameters for MongoDB pods"
   type = object({


### PR DESCRIPTION
This PR adds the possibility to override resources allocation for the MongoDB data pods which are quite low by default.