### PR TITLE
feat: deploy a sharded MongoDB

### DIFF
--- a/armonik/partitions-in-database-cron.tf
+++ b/armonik/partitions-in-database-cron.tf
@@ -174,9 +174,9 @@ resource "kubernetes_cron_job_v1" "partitions_in_database" {
 locals {
   script_cron = <<EOF
 #!/bin/bash
-export nbElements=$(mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?directConnection=false --eval 'db.PartitionData.countDocuments()' --quiet)
+export nbElements=$(mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource&directConnection=true --eval 'db.PartitionData.countDocuments()' --quiet)
 if [[ $nbElements != ${length(local.partition_names)} ]]; then
-  mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?directConnection=false --eval 'db.PartitionData.insertMany(${jsonencode(local.partitions_data)})'
+  mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource&directConnection=true --eval 'db.PartitionData.insertMany(${jsonencode(local.partitions_data)})'
 fi
 EOF
 }

--- a/armonik/partitions-in-database.tf
+++ b/armonik/partitions-in-database.tf
@@ -165,9 +165,9 @@ locals {
   script = <<EOF
 #!/bin/bash
 # Drop
-mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database --eval 'db.PartitionData.drop()'
+mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource --eval 'db.PartitionData.drop()'
 
 # Insert
-mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database --eval 'db.PartitionData.insertMany(${jsonencode(local.partitions_data)})'
+mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource --eval 'db.PartitionData.insertMany(${jsonencode(local.partitions_data)})'
 EOF
 }

--- a/storage/onpremise/mongodb-sharded/certificates.tf
+++ b/storage/onpremise/mongodb-sharded/certificates.tf
@@ -1,0 +1,77 @@
+#------------------------------------------------------------------------------
+# Certificate Authority
+#------------------------------------------------------------------------------
+resource "tls_private_key" "root_mongodb" {
+  algorithm   = "RSA"
+  ecdsa_curve = "P384"
+  rsa_bits    = "4096"
+}
+
+resource "tls_self_signed_cert" "root_mongodb" {
+  private_key_pem       = tls_private_key.root_mongodb.private_key_pem
+  is_ca_certificate     = true
+  validity_period_hours = var.validity_period_hours
+  allowed_uses = [
+    "cert_signing",
+    "key_encipherment",
+    "digital_signature"
+  ]
+  subject {
+    organization = "ArmoniK mongodb Root (NonTrusted)"
+    common_name  = "ArmoniK mongodb Root (NonTrusted) Private Certificate Authority"
+    country      = "France"
+  }
+}
+
+#------------------------------------------------------------------------------
+# Certificate
+#------------------------------------------------------------------------------
+resource "tls_private_key" "mongodb_private_key" {
+  algorithm   = "RSA"
+  ecdsa_curve = "P384"
+  rsa_bits    = "4096"
+}
+
+resource "tls_cert_request" "mongodb_cert_request" {
+  private_key_pem = tls_private_key.mongodb_private_key.private_key_pem
+  subject {
+    country     = "France"
+    common_name = "127.0.0.1"
+    # organization = "127.0.0.1"
+  }
+}
+
+resource "tls_locally_signed_cert" "mongodb_certificate" {
+  cert_request_pem      = tls_cert_request.mongodb_cert_request.cert_request_pem
+  ca_private_key_pem    = tls_private_key.root_mongodb.private_key_pem
+  ca_cert_pem           = tls_self_signed_cert.root_mongodb.cert_pem
+  validity_period_hours = var.validity_period_hours
+  allowed_uses = [
+    "key_encipherment",
+    "digital_signature",
+    "server_auth",
+    "client_auth",
+    "any_extended",
+  ]
+}
+
+#------------------------------------------------------------------------------
+# Kubernetes Secrets with certificates
+#------------------------------------------------------------------------------
+
+resource "kubernetes_secret" "mongodb_certificate" {
+  metadata {
+    name      = "${var.name}-server-certificates"
+    namespace = var.namespace
+  }
+  data = {
+    "mongodb.pem" = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_private_key.mongodb_private_key.private_key_pem)
+    "chain.pem"   = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_self_signed_cert.root_mongodb.cert_pem)
+  }
+}
+
+resource "local_sensitive_file" "mongodb_client_certificate" {
+  content         = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_self_signed_cert.root_mongodb.cert_pem)
+  filename        = "${path.root}/generated/certificates/${var.name}/chain.pem"
+  file_permission = "0600"
+}

--- a/storage/onpremise/mongodb-sharded/configmap.tf
+++ b/storage/onpremise/mongodb-sharded/configmap.tf
@@ -1,0 +1,38 @@
+locals {
+  database_init_script = <<EOF
+    db = db.getSiblingDB("${var.mongodb.database_name}");
+    db.createCollection("sample")
+    db.sample.insertOne({test:1})
+    db.createUser(
+    {
+        user: "${random_string.mongodb_application_user.result}",
+        pwd: "${random_password.mongodb_application_password.result}",
+        roles: [ 
+          {role: "readWrite", db: "${var.mongodb.database_name}" }, 
+          { role: "dbAdmin", db: "${var.mongodb.database_name}" }
+        ]
+    }
+    );
+    db.sample.drop()
+    db.adminCommand(
+    {
+      enableSharding: "${var.mongodb.database_name}"
+    }
+    );
+    EOF
+}
+
+resource "kubernetes_secret" "database_init_script" {
+  metadata {
+    name      = "${var.name}-database-init-script"
+    namespace = var.namespace
+  }
+  data = {
+    "initDatabase.js" = local.database_init_script
+  }
+}
+
+resource "local_sensitive_file" "init_script_file" {
+  content  = local.database_init_script
+  filename = "${path.root}/generated/${var.name}/configmaps/database_init_script.js"
+}

--- a/storage/onpremise/mongodb-sharded/credentials.tf
+++ b/storage/onpremise/mongodb-sharded/credentials.tf
@@ -1,0 +1,10 @@
+resource "random_string" "mongodb_application_user" {
+  length  = 8
+  special = false
+  numeric = false
+}
+
+resource "random_password" "mongodb_application_password" {
+  length  = 16
+  special = false
+}

--- a/storage/onpremise/mongodb-sharded/examples/complete/main.tf
+++ b/storage/onpremise/mongodb-sharded/examples/complete/main.tf
@@ -1,0 +1,106 @@
+module "sharded_mongodb" {
+  source    = "../../"
+  namespace = var.namespace
+  name      = "mongodb-sharded"
+  timeout   = 300
+
+  labels = {
+    shards = {
+      "role" = "dataHolder"
+    }
+
+    router = {
+      "role" = "distributer"
+    }
+
+    configsvr = {
+      "role" = "metadataHolder"
+    }
+  }
+
+  mongodb = {
+    helm_chart_repository = "oci://registry-1.docker.io/bitnamicharts"
+    helm_chart_version    = "8.3.8"
+    image_pull_secrets    = [""]
+    node_selector         = {}
+    registry              = "docker.io"
+    tag                   = "7.0.14-debian-12-r0"
+  }
+
+  sharding = {
+    shards = {
+      quantity = 2
+      replicas = 2
+    }
+
+    configsvr = {
+      replicas = 2
+    }
+
+    router = {
+      replicas = 2
+    }
+  }
+
+  persistence = {
+    shards = {
+      access_mode         = ["ReadWriteOnce"]
+      reclaim_policy      = "Retain"
+      storage_provisioner = "rancher.io/local-path"
+      resources = {
+        requests = {
+          storage = "8Gi"
+        }
+      }
+    }
+
+    configsvr = {
+      access_mode         = ["ReadWriteOnce"]
+      reclaim_policy      = "Delete"
+      storage_provisioner = "rancher.io/local-path"
+      resources = {
+        requests = {
+          storage = "1Gi"
+        }
+      }
+    }
+  }
+
+  resources = {
+    shards = {
+      limits = {
+        "cpu"    = "1"
+        "memory" = "2Gi"
+      }
+      requests = {
+        "cpu"    = "500m"
+        "memory" = "1Gi"
+      }
+    }
+
+    arbiter = {
+      limits = {
+        "cpu"    = "500m"
+        "memory" = "500Mi"
+      }
+    }
+
+    configsvr = {
+      limits = {
+        "cpu"    = "1"
+        "memory" = "1Gi"
+      }
+      requests = {
+        "cpu"    = "200m"
+        "memory" = "400Mi"
+      }
+    }
+
+    router = {
+      requests = {
+        "cpu"    = "400m"
+        "memory" = "700Mi"
+      }
+    }
+  }
+}

--- a/storage/onpremise/mongodb-sharded/examples/complete/outputs.tf
+++ b/storage/onpremise/mongodb-sharded/examples/complete/outputs.tf
@@ -1,0 +1,52 @@
+output "host" {
+  description = "Hostname or IP address of MongoDB server"
+  value       = module.sharded_mongodb.host
+}
+
+output "port" {
+  description = "Port of MongoDB server"
+  value       = module.sharded_mongodb.port
+}
+
+output "url" {
+  description = "URL of MongoDB server"
+  value       = module.sharded_mongodb.url
+}
+
+output "number_of_shards" {
+  description = "Number of MongoDB shards"
+  value       = module.sharded_mongodb.number_of_shards
+}
+
+output "number_of_replicas" {
+  description = "Number of replicas for each shard"
+  value       = module.sharded_mongodb.number_of_replicas
+}
+
+# SENSITIVE OUTPUTS
+output "user_credentials" {
+  description = "User credentials of MongoDB"
+  value       = module.sharded_mongodb.user_credentials
+  sensitive   = true
+}
+
+output "endpoints" {
+  description = "Endpoints of MongoDB"
+  value       = module.sharded_mongodb.endpoints
+  sensitive   = true
+}
+
+output "env" {
+  description = "Environment variables passed down to ArmoniK Core"
+  value       = module.sharded_mongodb.env
+}
+
+output "mount_secrets" {
+  description = "Secrets to be mounted as volumes"
+  value       = module.sharded_mongodb.mount_secret
+}
+
+output "env_from_secret" {
+  description = "Environment variables from secrets"
+  value       = module.sharded_mongodb.env_from_secret
+}

--- a/storage/onpremise/mongodb-sharded/examples/complete/providers.tf
+++ b/storage/onpremise/mongodb-sharded/examples/complete/providers.tf
@@ -1,0 +1,9 @@
+provider "helm" {
+  kubernetes {
+    config_path = var.kube_config_path
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kube_config_path
+}

--- a/storage/onpremise/mongodb-sharded/examples/complete/variables.tf
+++ b/storage/onpremise/mongodb-sharded/examples/complete/variables.tf
@@ -1,0 +1,11 @@
+variable "namespace" {
+  description = "Namespace of ArmoniK resources"
+  type        = string
+  default     = "default"
+}
+
+variable "kube_config_path" {
+  description = "The kubernetes configuration file path you want to specify"
+  type        = string
+  default     = "~/.kube/config"
+}

--- a/storage/onpremise/mongodb-sharded/examples/complete/versions.tf
+++ b/storage/onpremise/mongodb-sharded/examples/complete/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.10.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.21.1"
+    }
+  }
+}

--- a/storage/onpremise/mongodb-sharded/examples/simple/main.tf
+++ b/storage/onpremise/mongodb-sharded/examples/simple/main.tf
@@ -1,0 +1,11 @@
+module "sharded_mongodb" {
+  source    = "../../"
+  namespace = var.namespace
+  name      = "mongodb-sharded"
+  timeout   = 300
+
+  mongodb = {
+    helm_chart_version = "8.3.8"
+    tag                = "7.0.14-debian-12-r0"
+  }
+}

--- a/storage/onpremise/mongodb-sharded/examples/simple/outputs.tf
+++ b/storage/onpremise/mongodb-sharded/examples/simple/outputs.tf
@@ -1,0 +1,52 @@
+output "host" {
+  description = "Hostname or IP address of MongoDB server"
+  value       = module.sharded_mongodb.host
+}
+
+output "port" {
+  description = "Port of MongoDB server"
+  value       = module.sharded_mongodb.port
+}
+
+output "url" {
+  description = "URL of MongoDB server"
+  value       = module.sharded_mongodb.url
+}
+
+output "number_of_shards" {
+  description = "Number of MongoDB shards"
+  value       = module.sharded_mongodb.number_of_shards
+}
+
+output "number_of_replicas" {
+  description = "Number of replicas for each shard"
+  value       = module.sharded_mongodb.number_of_replicas
+}
+
+# SENSITIVE OUTPUTS
+output "user_credentials" {
+  description = "User credentials of MongoDB"
+  value       = module.sharded_mongodb.user_credentials
+  sensitive   = true
+}
+
+output "endpoints" {
+  description = "Endpoints of MongoDB"
+  value       = module.sharded_mongodb.endpoints
+  sensitive   = true
+}
+
+output "env" {
+  description = "Environment variables passed down to ArmoniK Core"
+  value       = module.sharded_mongodb.env
+}
+
+output "mount_secrets" {
+  description = "Secrets to be mounted as volumes"
+  value       = module.sharded_mongodb.mount_secret
+}
+
+output "env_from_secret" {
+  description = "Environment variables from secrets"
+  value       = module.sharded_mongodb.env_from_secret
+}

--- a/storage/onpremise/mongodb-sharded/examples/simple/providers.tf
+++ b/storage/onpremise/mongodb-sharded/examples/simple/providers.tf
@@ -1,0 +1,9 @@
+provider "helm" {
+  kubernetes {
+    config_path = var.kube_config_path
+  }
+}
+
+provider "kubernetes" {
+  config_path = var.kube_config_path
+}

--- a/storage/onpremise/mongodb-sharded/examples/simple/variables.tf
+++ b/storage/onpremise/mongodb-sharded/examples/simple/variables.tf
@@ -1,0 +1,11 @@
+variable "namespace" {
+  description = "Namespace of ArmoniK resources"
+  type        = string
+  default     = "default"
+}
+
+variable "kube_config_path" {
+  description = "The kubernetes configuration file path you want to specify"
+  type        = string
+  default     = "~/.kube/config"
+}

--- a/storage/onpremise/mongodb-sharded/examples/simple/versions.tf
+++ b/storage/onpremise/mongodb-sharded/examples/simple/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.2"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.10.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.21.1"
+    }
+  }
+}

--- a/storage/onpremise/mongodb-sharded/locals.tf
+++ b/storage/onpremise/mongodb-sharded/locals.tf
@@ -1,0 +1,6 @@
+locals {
+  mongodb_dns           = "${var.name}.${var.namespace}.svc.cluster.local"
+  mongodb_url           = "mongodb://${local.mongodb_dns}:${var.mongodb.service_port}/${var.mongodb.database_name}?authSource=admin"
+  mongodb_root_password = data.kubernetes_secret.mongodb_credentials.data["mongodb-root-password"]
+  mongodb_extra_flags   = ["--tlsMode=allowTLS", "--tlsCertificateKeyFile=/mongodb/mongodb.pem", "--tlsCAFile=/mongodb/chain.pem", "--tlsAllowConnectionsWithoutCertificates"]
+}

--- a/storage/onpremise/mongodb-sharded/main.tf
+++ b/storage/onpremise/mongodb-sharded/main.tf
@@ -1,0 +1,238 @@
+locals {
+  # To ensure image pull secrets are passed as an array/list and remove null value or empty strings
+  image_pull_secrets = compact(try(tolist(var.mongodb.image_pull_secrets), [tostring(var.mongodb.image_pull_secrets)]))
+  arbiter_replicas   = var.sharding.shards.replicas > 1 ? 1 : 0
+
+  configsvr_node_selector = coalesce(try(var.sharding.configsvr.node_selector, null), var.mongodb.node_selector)
+  router_node_selector    = coalesce(try(var.sharding.router.node_selector, null), var.mongodb.node_selector)
+  shards_node_selector    = coalesce(try(var.sharding.shards.node_selector, null), var.mongodb.node_selector)
+  arbiter_node_selector   = coalesce(try(var.sharding.arbiter.node_selector, null), var.mongodb.node_selector)
+
+  shards_labels    = try(var.labels.shardsvr, null)
+  arbiter_labels   = try(var.labels.arbiter, null)
+  configsvr_labels = try(var.labels.configsvr, null)
+  router_labels    = try(var.labels.router, null)
+
+  timeout = var.timeout * var.sharding.shards.quantity
+}
+
+resource "helm_release" "mongodb" {
+  name       = var.name
+  namespace  = var.namespace
+  chart      = var.mongodb.helm_chart_name
+  repository = var.mongodb.helm_chart_repository
+  version    = var.mongodb.helm_chart_version
+  timeout    = local.timeout
+
+  values = [
+    yamlencode({
+      "commonLabels" = var.default_labels
+      "shards"       = var.sharding.shards.quantity
+
+      "image" = {
+        "registry"    = var.mongodb.registry
+        "repository"  = var.mongodb.image
+        "tag"         = var.mongodb.tag
+        "pullSecrets" = local.image_pull_secrets
+      }
+
+      "auth" = {
+        "enabled" = true
+      }
+
+      "common" = {
+        "podLabels"                 = var.default_labels
+        "mongodbSystemLogVerbosity" = 5
+        "initScriptsSecret"         = kubernetes_secret.database_init_script.metadata[0].name
+        "extraEnvVarsSecret"        = kubernetes_secret.mongodb_user.metadata[0].name
+        "extraVolumes" = [{
+          name = "mongodb-cert"
+          secret = {
+            secretName = kubernetes_secret.mongodb_certificate.metadata[0].name
+          }
+        }]
+        "extraVolumeMounts" = [{
+          mountPath = "/mongodb/"
+          name      = "mongodb-cert"
+        }]
+      }
+
+      "volumePermissions" = {
+        "resourcesPreset" = "micro"
+      }
+
+      "service" = {
+        "ports.mongodb" = floor(var.mongodb.service_port)
+      }
+
+      "networkPolicy" = {
+        "enabled" = true
+      }
+
+      "configsvr" = {
+        "replicaCount"      = var.sharding.configsvr.replicas
+        "mongodbExtraFlags" = local.mongodb_extra_flags
+        "nodeSelector"      = local.configsvr_node_selector
+
+        "tolerations" = local.configsvr_node_selector != {} ? [
+          for key, value in local.configsvr_node_selector : {
+            "key"   = key
+            "value" = value
+          }
+        ] : []
+
+        "podLabels" = local.configsvr_labels
+        "resources" = var.resources.configsvr
+
+        "persistentVolumeClaimRetentionPolicy" = {
+          "enabled"     = true
+          "whenDeleted" = "Delete"
+        }
+
+        "podSecurityContext" = {
+          "fsGroup" = var.security_context.fs_group
+        }
+        "containerSecurityContext" = {
+          "runAsUser"  = var.security_context.run_as_user
+          "runAsGroup" = var.security_context.fs_group
+        }
+      }
+
+      "mongos" = {
+        "replicaCount"      = var.sharding.router.replicas
+        "mongodbExtraFlags" = local.mongodb_extra_flags
+        "nodeSelector"      = local.router_node_selector
+
+        "tolerations" = local.router_node_selector != {} ? [
+          for key, value in local.router_node_selector : {
+            "key"   = key
+            "value" = value
+          }
+        ] : []
+
+        "podLabels" = local.router_labels
+        "resources" = var.resources.router
+      }
+
+      "shardsvr" = {
+        "dataNode" = {
+          "replicaCount"      = var.sharding.shards.replicas
+          "mongodbExtraFlags" = local.mongodb_extra_flags
+          "nodeSelector"      = local.shards_node_selector
+
+          "tolerations" = local.shards_node_selector != {} ? [
+            for key, value in local.shards_node_selector : {
+              "key"   = key
+              "value" = value
+            }
+          ] : []
+
+          "podLabels" = local.shards_labels
+          "resources" = var.resources.shards
+
+          "persistentVolumeClaimRetentionPolicy" = {
+            "enabled"     = true
+            "whenDeleted" = "Delete"
+          }
+
+          "podSecurityContext" = {
+            "fsGroup" = var.security_context.fs_group
+          }
+          "containerSecurityContext" = {
+            "runAsUser"  = var.security_context.run_as_user
+            "runAsGroup" = var.security_context.fs_group
+          }
+        }
+
+        "arbiter" = {
+          "replicaCount"      = local.arbiter_replicas
+          "mongodbExtraFlags" = local.mongodb_extra_flags
+          "nodeSelector"      = local.arbiter_node_selector
+
+          "tolerations" = local.arbiter_node_selector != {} ? [
+            for key, value in local.arbiter_node_selector : {
+              "key"   = key
+              "value" = value
+            }
+          ] : []
+
+          "extraVolumeMounts" = [{
+            mountPath = "bitnami/mongodb/"
+            name      = "empty-dir"
+            subPath   = "app-volume-dir"
+          }]
+
+          "podLabels" = local.arbiter_labels
+          "resources" = var.resources.arbiter
+        }
+
+        # "metrics" = {
+        # }
+      }
+    })
+  ]
+
+  ### PERSISTENCE FOR DATABASE
+  dynamic "set" {
+    for_each = !can(coalesce(var.persistence.shards)) ? [1] : []
+
+    content {
+      name  = "shardsvr.persistence.enabled"
+      value = "false"
+    }
+  }
+  dynamic "set" {
+    for_each = can(coalesce(var.persistence.shards.storage_provisioner)) ? [1] : []
+    content {
+      name  = "shardsvr.persistence.storageClass"
+      value = kubernetes_storage_class.shards[0].metadata[0].name
+    }
+  }
+  dynamic "set" {
+    for_each = can(coalesce(var.persistence.shards)) ? [1] : []
+    content {
+      name  = "shardsvr.persistence.accessModes[0]"
+      value = var.persistence.shards.access_mode[0]
+    }
+  }
+  dynamic "set" {
+    for_each = can(coalesce(var.persistence.shards.resources.requests.storage)) ? [1] : []
+    content {
+      name  = "shardsvr.persistence.size"
+      value = var.persistence.shards.resources.requests.storage
+    }
+  }
+
+  ### PERSISTENCE FOR CONFIG SERVER
+  dynamic "set" {
+    for_each = !can(coalesce(var.persistence.configsvr)) ? [1] : []
+    content {
+      name  = "configsvr.persistence.enabled"
+      value = false
+    }
+  }
+  dynamic "set" {
+    for_each = can(coalesce(var.persistence.configsvr.storage_provisioner)) ? [1] : []
+    content {
+      name  = "configsvr.persistence.storageClass"
+      value = kubernetes_storage_class.configsvr[0].metadata[0].name
+    }
+  }
+  dynamic "set" {
+    for_each = can(coalesce(var.persistence.configsvr)) ? [1] : []
+    content {
+      name  = "configsvr.persistence.accessModes[0]"
+      value = var.persistence.configsvr.access_mode[0]
+    }
+  }
+  dynamic "set" {
+    for_each = can(coalesce(var.persistence.configsvr.resources.requests.storage)) ? [1] : []
+    content {
+      name  = "configsvr.persistence.size"
+      value = var.persistence.configsvr.resources.requests.storage
+    }
+  }
+
+  # Setting this explicit dependency avoids a deadlock at destruction
+  depends_on = [kubernetes_storage_class.configsvr, kubernetes_storage_class.shards]
+}

--- a/storage/onpremise/mongodb-sharded/outputs.tf
+++ b/storage/onpremise/mongodb-sharded/outputs.tf
@@ -1,0 +1,82 @@
+output "host" {
+  description = "Hostname or IP address of MongoDB server"
+  value       = local.mongodb_dns
+}
+
+output "port" {
+  description = "Port of MongoDB server"
+  value       = var.mongodb.service_port
+}
+
+output "url" {
+  description = "URL of MongoDB server"
+  value       = local.mongodb_url
+}
+
+output "number_of_replicas" {
+  description = "Number of replicas for each shard"
+  value       = var.sharding.shards.replicas
+}
+
+output "number_of_shards" {
+  description = "Number of MongoDB shards"
+  value       = var.sharding.shards
+}
+
+output "user_credentials" {
+  description = "User credentials of MongoDB"
+  value = {
+    secret    = kubernetes_secret.mongodb_user.metadata[0].name
+    data_keys = keys(kubernetes_secret.mongodb_user.data)
+  }
+}
+
+output "endpoints" {
+  description = "Endpoints of MongoDB"
+  value = {
+    secret    = kubernetes_secret.mongodb.metadata[0].name
+    data_keys = keys(kubernetes_secret.mongodb.data)
+  }
+}
+
+#new Outputs 
+output "env" {
+  description = "Elements to be set as environment variables"
+  value = ({
+    "Components__TableStorage"  = "ArmoniK.Adapters.MongoDB.TableStorage"
+    "MongoDB__Host"             = local.mongodb_dns
+    "MongoDB__Port"             = var.mongodb.service_port
+    "MongoDB__Tls"              = "true"
+    "MongoDB__ReplicaSet"       = "rs0"
+    "MongoDB__DatabaseName"     = "database"
+    "MongoDB__DirectConnection" = "true"
+    "MongoDB__CAFile"           = "/mongodb/certs/chain.pem"
+    "MongoDB__Sharding"         = "true"
+    "MongoDB__AuthSource"       = "admin"
+  })
+}
+
+output "mount_secret" {
+  description = "Secrets to be mounted as volumes"
+  value = {
+    "mongo-certificate" = {
+      secret = kubernetes_secret.mongodb.metadata[0].name
+      path   = "/mongodb/certs/"
+      mode   = "0644"
+    }
+  }
+}
+
+output "env_from_secret" {
+  description = "Environment variables from secrets"
+  value = {
+    "MongoDB__User" = {
+      secret = kubernetes_secret.mongodb_admin.metadata[0].name
+      field  = "MONGO_USERNAME"
+    },
+    "MongoDB__Password" = {
+      secret = kubernetes_secret.mongodb_admin.metadata[0].name
+      field  = "MONGO_PASSWORD"
+    }
+  }
+}

--- a/storage/onpremise/mongodb-sharded/persistence.tf
+++ b/storage/onpremise/mongodb-sharded/persistence.tf
@@ -1,0 +1,35 @@
+resource "kubernetes_storage_class" "shards" {
+  # enable if var.persistence.shards is not null and var.persistence.shards.storage_provisioner is neither null nor empty
+  count = can(coalesce(var.persistence.shards.storage_provisioner)) ? 1 : 0
+  metadata {
+    name = "${var.name}-shards"
+    labels = {
+      app     = "mongodb"
+      type    = "storage-class"
+      service = "persistent-volume"
+    }
+  }
+  mount_options       = ["tls"]
+  storage_provisioner = var.persistence.shards.storage_provisioner
+  reclaim_policy      = var.persistence.shards.reclaim_policy
+  volume_binding_mode = var.persistence.shards.volume_binding_mode
+  parameters          = var.persistence.shards.parameters
+}
+
+resource "kubernetes_storage_class" "configsvr" {
+  # enable if var.persistence.configsvr.storage_provisioner is neither null nor empty
+  count = can(coalesce(var.persistence.configsvr.storage_provisioner)) ? 1 : 0
+  metadata {
+    name = "${var.name}-configsvr"
+    labels = {
+      app     = "mongodb"
+      type    = "storage-class"
+      service = "persistent-volume"
+    }
+  }
+  mount_options       = ["tls"]
+  storage_provisioner = var.persistence.configsvr.storage_provisioner
+  reclaim_policy      = var.persistence.configsvr.reclaim_policy
+  volume_binding_mode = var.persistence.configsvr.volume_binding_mode
+  parameters          = var.persistence.configsvr.parameters
+}

--- a/storage/onpremise/mongodb-sharded/secrets.tf
+++ b/storage/onpremise/mongodb-sharded/secrets.tf
@@ -1,0 +1,47 @@
+data "kubernetes_secret" "mongodb_credentials" {
+  metadata {
+    name      = helm_release.mongodb.name
+    namespace = var.namespace
+  }
+  depends_on = [helm_release.mongodb]
+}
+
+resource "kubernetes_secret" "mongodb_admin" {
+  metadata {
+    name      = "${var.name}-admin"
+    namespace = var.namespace
+  }
+  data = {
+    MONGO_USERNAME = "root"
+    MONGO_PASSWORD = local.mongodb_root_password
+  }
+}
+
+resource "kubernetes_secret" "mongodb_user" {
+  metadata {
+    name      = "${var.name}-user"
+    namespace = var.namespace
+  }
+  data = {
+    # When using Bitnami's MongoDB image, MONGODB_USERNAME and MONGODB_PASSWORD are forbidden env variables names, see https://github.com/bitnami/containers/issues/18506
+    MONGO_USERNAME = random_string.mongodb_application_user.result
+    MONGO_PASSWORD = random_password.mongodb_application_password.result
+  }
+}
+
+resource "kubernetes_secret" "mongodb" {
+  metadata {
+    name      = "custom-${var.name}"
+    namespace = helm_release.mongodb.namespace
+  }
+  data = {
+    "chain.pem"        = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_self_signed_cert.root_mongodb.cert_pem)
+    username           = random_string.mongodb_application_user.result
+    password           = random_password.mongodb_application_password.result
+    host               = local.mongodb_dns
+    port               = var.mongodb.service_port
+    url                = local.mongodb_url
+    number_of_replicas = var.sharding.shards.replicas
+    number_of_shards   = var.sharding.shards.quantity
+  }
+}

--- a/storage/onpremise/mongodb-sharded/variables.tf
+++ b/storage/onpremise/mongodb-sharded/variables.tf
@@ -1,0 +1,180 @@
+variable "namespace" {
+  description = "Namespace of ArmoniK resources"
+  type        = string
+  default     = "default"
+}
+
+variable "default_labels" {
+  description = "Default labels for the MongoDB-related Kubernetes pods"
+  type        = map(string)
+  default = {
+    "app"  = "storage"
+    "type" = "table"
+  }
+}
+
+variable "labels" {
+  description = "Custom labels for the different MongoDB entities"
+  type = object({
+    shards    = optional(map(string))
+    arbiter   = optional(map(string))
+    configsvr = optional(map(string))
+    router    = optional(map(string))
+  })
+  default = null
+}
+
+variable "name" {
+  description = "Name used for the helm chart release and the associated resources, must be shorter than 54 characters"
+  type        = string
+  default     = "mongodb-sharded" # Ideally not change it, cause it makes the create kube service name hard to manage
+  # resulting in a false connection string output
+}
+
+variable "mongodb" {
+  description = "Parameters of the MongoDB deployment"
+
+  type = object({
+    database_name         = optional(string, "database")
+    helm_chart_repository = optional(string, "oci://registry-1.docker.io/bitnamicharts")
+    helm_chart_name       = optional(string, "mongodb-sharded")
+    helm_chart_version    = string
+    image                 = optional(string, "bitnami/mongodb-sharded")
+    image_pull_secrets    = optional(any, [""]) # can be a string or a list of strings
+    node_selector         = optional(map(string), {})
+    registry              = optional(string)
+    service_port          = optional(number, 27017)
+    tag                   = string
+  })
+
+  validation {
+    condition     = var.mongodb.service_port >= 0 && var.mongodb.service_port < 65536
+    error_message = "MongoDB service port must be a number between 0 included and 65535 included"
+  }
+}
+
+variable "sharding" {
+  description = "Parameters specific to the sharded architecture"
+  type = object({
+    shards = optional(object({
+      quantity      = optional(number, 2)
+      replicas      = optional(number, 1)
+      node_selector = optional(map(string))
+    }))
+
+    arbiter = optional(object({
+      node_selector = optional(map(string))
+    }))
+
+    router = optional(object({
+      replicas      = optional(number, 2)
+      node_selector = optional(map(string))
+    }))
+
+    configsvr = optional(object({
+      replicas      = optional(number, 1)
+      node_selector = optional(map(string))
+    }))
+  })
+  default = {
+    shards    = {}
+    arbiter   = {}
+    router    = {}
+    configsvr = {}
+  }
+}
+
+variable "resources" {
+  description = "Resources requests and limitations (cpu, memory, ephemeral-storage) for different types of MongoDB entities"
+  type = object({
+    shards = optional(object({
+      limits   = optional(map(string))
+      requests = optional(map(string))
+    }))
+
+    arbiter = optional(object({
+      limits   = optional(map(string))
+      requests = optional(map(string))
+    }))
+
+    configsvr = optional(object({
+      limits   = optional(map(string))
+      requests = optional(map(string))
+    }))
+
+    router = optional(object({
+      limits   = optional(map(string))
+      requests = optional(map(string))
+    }))
+  })
+  default = {
+    shards    = {}
+    arbiter   = {}
+    router    = {}
+    configsvr = {}
+  }
+}
+
+variable "persistence" {
+  description = "Persistence parameters for MongoDB"
+  type = object({
+    shards = optional(object({
+      access_mode         = optional(list(string), ["ReadWriteOnce"])
+      reclaim_policy      = optional(string, "Delete")
+      storage_provisioner = optional(string, "")
+      volume_binding_mode = optional(string, "WaitForFirstConsumer")
+      parameters          = optional(map(string), {})
+
+      resources = optional(object({
+        limits = optional(object({
+          storage = string
+        }))
+        requests = optional(object({
+          storage = string
+        }))
+      }))
+    }))
+
+    configsvr = optional(object({
+      access_mode         = optional(list(string), ["ReadWriteOnce"])
+      reclaim_policy      = optional(string, "Delete")
+      storage_provisioner = optional(string, "")
+      volume_binding_mode = optional(string, "WaitForFirstConsumer")
+      parameters          = optional(map(string), {})
+
+      resources = optional(object({
+        limits = optional(object({
+          storage = string
+        }))
+        requests = optional(object({
+          storage = string
+        }))
+      }))
+    }))
+  })
+  default = null
+}
+
+variable "security_context" {
+  description = "Security context for MongoDB pods"
+  type = object({
+    run_as_user = number
+    fs_group    = number
+  })
+  default = {
+    run_as_user = 999
+    fs_group    = 999
+  }
+}
+
+variable "timeout" {
+  description = "Timeout limit in seconds per shard for the helm release creation"
+  type        = number
+  default     = 180
+}
+
+variable "validity_period_hours" {
+  description = "Validity period of the TLS certificate in hours"
+  type        = string
+  default     = "8760" # 1 year
+}

--- a/storage/onpremise/mongodb-sharded/versions.tf
+++ b/storage/onpremise/mongodb-sharded/versions.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.3"
+  required_providers {
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.10.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.5.1"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.21.1"
+    }
+    local = {
+      source  = "hashicorp/local"
+      version = ">= 2.4.0"
+    }
+    tls = {
+      source  = "hashicorp/tls"
+      version = ">= 4.0.4"
+    }
+  }
+}


### PR DESCRIPTION
# Motivation

Described in AEP 004. This PR is meant to treat a previsible bottleneck on ArmoniK's database by enabling a sharded architecture to it.

# Description

This PR adds a new module ` mongodb-sharded` that calls a Helm chart deploying a sharded MongoDB (by default [Bitnami's](https://artifacthub.io/packages/helm/bitnami/mongodb-sharded)). It is both out-of-the-box and configurable : number of shards, number of replicas, node selectors and labels for each MongoDB entities, persistence, etc.

# Testing

The two examples modules test this new module : one deploys it with a complete redefinition of the configuration, the other with all the default values

# Impact

It is expected to enhance ArmoniK's strong scalability at the cost of simple database configuration. A sharded database is indeed more complex. 

# Warning

Theses developments were made using Bitnami's mongodb-sharded [image](https://github.com/bitnami/containers/tree/main/bitnami/mongodb-sharded) and [Helm chart](https://github.com/bitnami/charts/tree/main/bitnami/mongodb-sharded). It is not guaranteed  that they work without using these particular resources.

As Bitnami's images are not verified with Docker Scout, we advice to adapt Bitnami's mongodb-sharded image to make it compliant with your personnal or business security requirements.

# Additional Information

To better understand how MongoDB sharding works see [MongoDB's documentation](https://www.mongodb.com/docs/manual/sharding/).

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] I have thoroughly tested my modifications and added tests when necessary.
- [X] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.