### PR TITLE
fix: remove connection http headers from ingress responses

### DIFF
--- a/armonik/ingress-configmap.tf
+++ b/armonik/ingress-configmap.tf
@@ -87,10 +87,6 @@ server {
         proxy_send_timeout 1d;
         grpc_read_timeout 30d;
         grpc_send_timeout 1d;
-
-        # Try force keep alive
-        add_header Connection Keep-Alive;
-        add_header Proxy-Connection Keep-Alive;
     }
 
     location /static/ {


### PR DESCRIPTION
These headers break the java client as they are not needed in http2

