### PR TITLE
refactor: update MongoDB outputs

### DIFF
--- a/storage/onpremise/mongodb/outputs.tf
+++ b/storage/onpremise/mongodb/outputs.tf
@@ -38,8 +38,6 @@ output "endpoints" {
 output "unused_variables" {
   description = "Map of variables that are not used yet but might be in the future"
   value = {
-    "persistent_volume"     = var.persistent_volume
-    "security_context"      = var.security_context
     "validity_period_hours" = var.validity_period_hours
   }
 }

--- a/storage/onpremise/mongodb/outputs.tf
+++ b/storage/onpremise/mongodb/outputs.tf
@@ -56,6 +56,7 @@ output "env" {
     "MongoDB__DatabaseName"     = "database"
     "MongoDB__DirectConnection" = "false"
     "MongoDB__CAFile"           = "/mongodb/certificate/mongodb-ca-cert"
+    "MongoDB__AuthSource"       = "database"
   })
 
 }


### PR DESCRIPTION
# Motivation

In prevision of #168 which will slightly modify partitions-in-database jobs by requiring a `MongoDB__AuthSource` env variable to run correctly, this PR preventively treats an error status for this job that would prevent from deploying ArmoniK.

It also updates the `unused_variables` output. As a reminder, this output was added to pass Terraform linting : unused variables were left in the code to avoid breaking change in https://github.com/aneoconsulting/ArmoniK .

# Description

This PR simply adds an entry to the `env` output with key `MongoDB__AuthSource` and a value hard-coded to `database`, and also removes the entries `persistent_volume` and `security_context` from the `unused_variables` output.

# Testing

After #168 and https://github.com/aneoconsulting/ArmoniK/pull/1321 are merged, the test can be done by nullifying the upcoming `mongodb_sharding` variable in quick-deploy's `parameters.tfvars`.

# Impact

`partitions-in-database` jobs will complete whether MongoDB is deployed with mongodb-sharded module or mongodb module.

# Additional Information

This PR has no effect as long as #168 is not merged.

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [X] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.