### PR TITLE
feat: Added Percona's MongoDB exporter to observe database related metrics

### DIFF
--- a/monitoring/onpremise/exporters/mongodb-exporter/README.md
+++ b/monitoring/onpremise/exporters/mongodb-exporter/README.md
@@ -1,0 +1,41 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.21.1 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.21.1 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [kubernetes_deployment.mongodb_exporter](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/deployment) | resource |
+| [kubernetes_service.mongodb_exporter_service](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_certif_mount"></a> [certif\_mount](#input\_certif\_mount) | MongoDB certificate mount secret | <pre>map(object({<br>    secret = string<br>    path   = string<br>    mode   = string<br>  }))</pre> | n/a | yes |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image for partition metrics exporter | <pre>object({<br>    image              = string<br>    tag                = string<br>    image_pull_secrets = string<br>  })</pre> | n/a | yes |
+| <a name="input_mongo_url"></a> [mongo\_url](#input\_mongo\_url) | Full MongoDB URI with credentials and tls options included | `string` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK resources | `string` | n/a | yes |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_namespace"></a> [namespace](#output\_namespace) | Namespace of the MongoDB metrics exporter |
+| <a name="output_url"></a> [url](#output\_url) | Url of the MongoDB Metrics exporter |
+<!-- END_TF_DOCS -->

--- a/monitoring/onpremise/exporters/mongodb-exporter/main.tf
+++ b/monitoring/onpremise/exporters/mongodb-exporter/main.tf
@@ -1,0 +1,96 @@
+resource "kubernetes_deployment" "mongodb_exporter" {
+  metadata {
+    name      = "mongodb-metrics-exporter"
+    namespace = var.namespace
+    labels = {
+      app     = "armonik"
+      type    = "monitoring"
+      service = "mongodb-metrics-exporter"
+    }
+  }
+
+  spec {
+    replicas = 1
+    selector {
+      match_labels = {
+        app     = "armonik"
+        type    = "monitoring"
+        service = "mongodb-metrics-exporter"
+      }
+    }
+
+    template {
+      metadata {
+        name      = "mongodb-metrics-exporter"
+        namespace = var.namespace
+        labels = {
+          app     = "armonik"
+          type    = "monitoring"
+          service = "mongodb-metrics-exporter"
+        }
+      }
+      spec {
+        container {
+          name  = "mongodb-metrics-exporter"
+          image = var.docker_image.tag != "" ? "${var.docker_image.image}:${var.docker_image.tag}" : var.docker_image.image
+
+          env {
+            name  = "MONGODB_URI"
+            value = var.mongo_url
+          }
+
+          dynamic "volume_mount" {
+            for_each = var.certif_mount
+            content {
+              mount_path = volume_mount.value.path
+              name       = volume_mount.value.secret
+              read_only  = true
+            }
+          }
+
+          args = ["--log.level=error", "--collector.diagnosticdata", "--collector.replicasetstatus", "--collector.dbstats", "--collector.dbstatsfreestorage", "--collector.topmetrics", "--collector.currentopmetrics", "--collector.indexstats", "--collector.collstats", "--discovering-mode", "--mongodb.uri=$(MONGODB_URI)"]
+        }
+
+        dynamic "volume" {
+          for_each = var.certif_mount
+          content {
+            name = volume.value.secret
+            secret {
+              secret_name  = volume.value.secret
+              default_mode = volume.value.mode
+            }
+          }
+        }
+
+      }
+    }
+  }
+}
+
+resource "kubernetes_service" "mongodb_exporter_service" {
+  metadata {
+    name      = "mongodb-metrics-exporter"
+    namespace = var.namespace
+    labels = {
+      app     = "armonik"
+      type    = "monitoring"
+      service = "mongodb-metrics-exporter"
+    }
+  }
+
+  spec {
+    selector = {
+      app     = "armonik"
+      type    = "monitoring"
+      service = "mongodb-metrics-exporter"
+    }
+
+    port {
+      port        = 9216
+      target_port = 9216
+      protocol    = "TCP"
+    }
+
+    type = "ClusterIP"
+  }
+}

--- a/monitoring/onpremise/exporters/mongodb-exporter/outputs.tf
+++ b/monitoring/onpremise/exporters/mongodb-exporter/outputs.tf
@@ -1,0 +1,11 @@
+# MongoDB metrics exporter
+
+output "url" {
+  description = "Url of the MongoDB Metrics exporter"
+  value       = "${kubernetes_service.mongodb_exporter_service.spec[0].cluster_ip}:${kubernetes_service.mongodb_exporter_service.spec[0].port[0].port}"
+}
+
+output "namespace" {
+  description = "Namespace of the MongoDB metrics exporter"
+  value       = var.namespace
+}

--- a/monitoring/onpremise/exporters/mongodb-exporter/variables.tf
+++ b/monitoring/onpremise/exporters/mongodb-exporter/variables.tf
@@ -1,0 +1,29 @@
+# Global variables
+variable "namespace" {
+  description = "Namespace of ArmoniK resources"
+  type        = string
+}
+
+# Docker image
+variable "docker_image" {
+  description = "Docker image for partition metrics exporter"
+  type = object({
+    image              = string
+    tag                = string
+    image_pull_secrets = string
+  })
+}
+
+variable "certif_mount" {
+  description = "MongoDB certificate mount secret"
+  type = map(object({
+    secret = string
+    path   = string
+    mode   = string
+  }))
+}
+
+variable "mongo_url" {
+  description = "Full MongoDB URI with credentials and tls options included"
+  type        = string
+}

--- a/monitoring/onpremise/exporters/mongodb-exporter/versions.tf
+++ b/monitoring/onpremise/exporters/mongodb-exporter/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.21.1"
+    }
+  }
+}

--- a/monitoring/onpremise/prometheus/README.md
+++ b/monitoring/onpremise/prometheus/README.md
@@ -41,6 +41,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image for Prometheus | <pre>object({<br>    image              = string<br>    tag                = string<br>    image_pull_secrets = string<br>  })</pre> | n/a | yes |
 | <a name="input_metrics_exporter_url"></a> [metrics\_exporter\_url](#input\_metrics\_exporter\_url) | URL of metrics exporter | `string` | n/a | yes |
+| <a name="input_mongo_metrics_exporter_url"></a> [mongo\_metrics\_exporter\_url](#input\_mongo\_metrics\_exporter\_url) | URL of the MongoDB metrics exporter | `string` | `null` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK monitoring | `string` | n/a | yes |
 | <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for Prometheus | `any` | `{}` | no |
 | <a name="input_persistent_volume"></a> [persistent\_volume](#input\_persistent\_volume) | Persistent volume info | <pre>object({<br>    storage_provisioner = string<br>    volume_binding_mode = string<br>    parameters          = map(string)<br>    # Resources for PVC<br>    resources = object({<br>      limits = object({<br>        storage = string<br>      })<br>      requests = object({<br>        storage = string<br>      })<br>    })<br>  })</pre> | `null` | no |

--- a/monitoring/onpremise/prometheus/prometheus-configmap.tf
+++ b/monitoring/onpremise/prometheus/prometheus-configmap.tf
@@ -23,6 +23,14 @@ scrape_configs:
       - targets: ["${var.metrics_exporter_url}"]
         labels:
           namespace: "${var.namespace}"
+          
+  - job_name: "mongodb-metrics-exporter"
+    static_configs: 
+      - targets: ["${var.mongo_metrics_exporter_url}"]
+        labels:
+          namespace: "${var.namespace}"
+    metrics_path: /metrics
+    scheme: http
 
   - job_name: "kubernetes-apiservers"
     kubernetes_sd_configs:

--- a/monitoring/onpremise/prometheus/variables.tf
+++ b/monitoring/onpremise/prometheus/variables.tf
@@ -33,6 +33,13 @@ variable "metrics_exporter_url" {
   type        = string
 }
 
+# MongoDB metrics exporter url 
+variable "mongo_metrics_exporter_url" {
+  description = "URL of the MongoDB metrics exporter"
+  type        = string
+  default     = null
+}
+
 variable "security_context" {
   description = "security context for Prometheus pods"
   type = object({

--- a/storage/onpremise/mongodb/createClusterMonitor.js
+++ b/storage/onpremise/mongodb/createClusterMonitor.js
@@ -1,0 +1,9 @@
+use admin;
+db.createUser({
+  user: "mongodb_exporter",
+  pwd: "mongodb_exporter",
+  roles: [
+    { role: "clusterMonitor", db: "admin"},
+    { role: "read", db: "local"}
+  ]
+});

--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -47,7 +47,9 @@ resource "helm_release" "mongodb" {
       "auth" = {
         "databases" = ["database"]
       }
-
+      "initdbScripts" = {
+        "createClusterMonitor.js" = file("${path.module}/createClusterMonitor.js")
+      }
       "podSecurityContext" = {
         "fsGroup" = var.security_context.fs_group
       }


### PR DESCRIPTION
## Motivation
 
We needed a way to extract the metrics that MongoDB already exposes to us for either visualization through Grafana or over-time tracking with Prometheus. These are per-collection and per-operation metrics that can later be used for a more targetted analysis with regards to the database's health and performance.
 
## Description
 
Added a Kubernetes deployment of Percona's MongoDB metrics exporter, automated the creation of a new ```clusterMonitor``` user to obtain database metrics and changed Prometheus's config map for it to retrieve stats from the exporter's endpoint. 
 
## Testing
 
Tested with a [pre-existing](https://grafana.com/grafana/dashboards/20867-mongodb-dashboard/) dashboard for this exporter. You can also look at the mongodb prometheus metrics (with a ```mongo_``` prefix) in Grafana's metrics tab to see if they're being exported correctly. 
 
## Impact
 
No significant direct impact on ArmoniK's performance or on how it functions. 
 
## Additional Information
 
Exporting metrics from the database profiler is disabled, because to do so, we'd need to configure our mongodb deployment for this and it would have a significant performance impact. Nevertheless, it would be interesting to explore the profiler options allowing us to log slow queries for certain stress tests that revolve around the database. [There is one](https://www.mongodb.com/docs/cloud-manager/performance-advisor/slow-query-threshold/) that allows us to define a duration threshold for operations that above which they get logged.
 
## Checklist
 
- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.