### PR TITLE
fix: change default value for MongoDB metrics exporter URL

### DIFF
--- a/monitoring/onpremise/prometheus/README.md
+++ b/monitoring/onpremise/prometheus/README.md
@@ -41,7 +41,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image for Prometheus | <pre>object({<br>    image              = string<br>    tag                = string<br>    image_pull_secrets = string<br>  })</pre> | n/a | yes |
 | <a name="input_metrics_exporter_url"></a> [metrics\_exporter\_url](#input\_metrics\_exporter\_url) | URL of metrics exporter | `string` | n/a | yes |
-| <a name="input_mongo_metrics_exporter_url"></a> [mongo\_metrics\_exporter\_url](#input\_mongo\_metrics\_exporter\_url) | URL of the MongoDB metrics exporter | `string` | `null` | no |
+| <a name="input_mongo_metrics_exporter_url"></a> [mongo\_metrics\_exporter\_url](#input\_mongo\_metrics\_exporter\_url) | URL of the MongoDB metrics exporter | `string` | `""` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK monitoring | `string` | n/a | yes |
 | <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for Prometheus | `any` | `{}` | no |
 | <a name="input_persistent_volume"></a> [persistent\_volume](#input\_persistent\_volume) | Persistent volume info | <pre>object({<br>    storage_provisioner = string<br>    volume_binding_mode = string<br>    parameters          = map(string)<br>    # Resources for PVC<br>    resources = object({<br>      limits = object({<br>        storage = string<br>      })<br>      requests = object({<br>        storage = string<br>      })<br>    })<br>  })</pre> | `null` | no |

--- a/monitoring/onpremise/prometheus/variables.tf
+++ b/monitoring/onpremise/prometheus/variables.tf
@@ -37,7 +37,7 @@ variable "metrics_exporter_url" {
 variable "mongo_metrics_exporter_url" {
   description = "URL of the MongoDB metrics exporter"
   type        = string
-  default     = null
+  default     = ""
 }
 
 variable "security_context" {


### PR DESCRIPTION
Fix deployment break introduced by #175 by replacing `mongo_metrics_exporter_url` `null` default value with empty string.