### PR TITLE
fix: node selector support for node_exporter and fluent-bit

### DIFF
--- a/monitoring/onpremise/exporters/node-exporter/README.md
+++ b/monitoring/onpremise/exporters/node-exporter/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.21.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.26.0 |
 
 ## Modules
 

--- a/monitoring/onpremise/exporters/node-exporter/README.md
+++ b/monitoring/onpremise/exporters/node-exporter/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.26.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.21.1 |
 
 ## Modules
 

--- a/monitoring/onpremise/exporters/node-exporter/locals.tf
+++ b/monitoring/onpremise/exporters/node-exporter/locals.tf
@@ -1,4 +1,5 @@
 locals {
-  node_selector_keys   = keys(var.node_selector)
-  node_selector_values = values(var.node_selector)
+  node_selector_keys          = keys(var.node_selector)
+  node_selector_values        = values(var.node_selector)
+  node_exporter_node_selector = try(var.node_selector, {})
 }

--- a/monitoring/onpremise/exporters/node-exporter/locals.tf
+++ b/monitoring/onpremise/exporters/node-exporter/locals.tf
@@ -1,5 +1,0 @@
-locals {
-  node_selector_keys          = keys(var.node_selector)
-  node_selector_values        = values(var.node_selector)
-  node_exporter_node_selector = try(var.node_selector, {})
-}

--- a/monitoring/onpremise/exporters/node-exporter/main.tf
+++ b/monitoring/onpremise/exporters/node-exporter/main.tf
@@ -32,6 +32,7 @@ resource "kubernetes_daemonset" "node_exporter" {
         }
       }
       spec {
+        node_selector = local.node_exporter_node_selector
         dynamic "toleration" {
           for_each = (var.node_selector != {} ? [
             for index in range(0, length(local.node_selector_keys)) : {

--- a/monitoring/onpremise/exporters/node-exporter/main.tf
+++ b/monitoring/onpremise/exporters/node-exporter/main.tf
@@ -34,7 +34,7 @@ resource "kubernetes_daemonset" "node_exporter" {
       spec {
         node_selector = var.node_selector
         dynamic "toleration" {
-          for_each = var.node_selector != {} ? var.node_selector : {}
+          for_each = var.node_selector
           content {
             key      = toleration.key
             operator = "Equal"

--- a/monitoring/onpremise/exporters/node-exporter/main.tf
+++ b/monitoring/onpremise/exporters/node-exporter/main.tf
@@ -32,18 +32,13 @@ resource "kubernetes_daemonset" "node_exporter" {
         }
       }
       spec {
-        node_selector = local.node_exporter_node_selector
+        node_selector = var.node_selector
         dynamic "toleration" {
-          for_each = (var.node_selector != {} ? [
-            for index in range(0, length(local.node_selector_keys)) : {
-              key   = local.node_selector_keys[index]
-              value = local.node_selector_values[index]
-            }
-          ] : [])
+          for_each = var.node_selector != {} ? var.node_selector : {}
           content {
-            key      = toleration.value.key
+            key      = toleration.key
             operator = "Equal"
-            value    = toleration.value.value
+            value    = toleration.value
             effect   = "NoSchedule"
           }
         }

--- a/monitoring/onpremise/fluent-bit/locals.tf
+++ b/monitoring/onpremise/fluent-bit/locals.tf
@@ -14,8 +14,6 @@ locals {
   fluent_bit_image_pull_secrets                 = try(var.fluent_bit.image_pull_secrets, "")
   fluent_bit_var_lib_docker_containers_hostpath = try(var.fluent_bit.var_lib_docker_containers_hostpath, "/var/lib/docker/containers")
   fluent_bit_run_log_journal_hostpath           = try(var.fluent_bit.run_log_journal_hostpath, "/run/log/journal")
-  fluent_bit_node_selector_keys                 = keys(var.node_selector)
-  fluent_bit_node_selector_values               = values(var.node_selector)
 
   # Seq
   seq_host    = try(var.seq.host, "")

--- a/monitoring/onpremise/fluent-bit/main.tf
+++ b/monitoring/onpremise/fluent-bit/main.tf
@@ -26,7 +26,7 @@ resource "kubernetes_daemonset" "fluent_bit" {
       spec {
         node_selector = var.node_selector
         dynamic "toleration" {
-          for_each = var.node_selector != {} ? var.node_selector : {}
+          for_each = var.node_selector
           content {
             key      = toleration.key
             operator = "Equal"

--- a/monitoring/onpremise/fluent-bit/main.tf
+++ b/monitoring/onpremise/fluent-bit/main.tf
@@ -24,17 +24,13 @@ resource "kubernetes_daemonset" "fluent_bit" {
         }
       }
       spec {
+        node_selector = var.node_selector
         dynamic "toleration" {
-          for_each = (var.node_selector != {} ? [
-            for index in range(0, length(local.fluent_bit_node_selector_keys)) : {
-              key   = local.fluent_bit_node_selector_keys[index]
-              value = local.fluent_bit_node_selector_values[index]
-            }
-          ] : [])
+          for_each = var.node_selector != {} ? var.node_selector : {}
           content {
-            key      = toleration.value.key
+            key      = toleration.key
             operator = "Equal"
-            value    = toleration.value.value
+            value    = toleration.value
             effect   = "NoSchedule"
           }
         }


### PR DESCRIPTION
# Motivation
The node selectors are not applied to fluent-bit pods and node_exporters even if they are correctly defined.

# Description

Adding the defined node selectors to the daemonset definition

# Testing

N/A

# Impact
Pods will be created and scheduled only on the nodes satisfying the node selectors

# Additional Information



# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.