### PR TITLE
fix: eks module update to version 20.29.0

### DIFF
--- a/container-registry/aws/ecr/README.md
+++ b/container-registry/aws/ecr/README.md
@@ -22,7 +22,7 @@ This module must be used with these constraints:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_generic"></a> [generic](#requirement\_generic) | >= 0.1.1 |
 | <a name="requirement_skopeo2"></a> [skopeo2](#requirement\_skopeo2) | >= 1.1.1 |
 
@@ -30,7 +30,7 @@ This module must be used with these constraints:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 | <a name="provider_generic"></a> [generic](#provider\_generic) | >= 0.1.1 |
 | <a name="provider_skopeo2"></a> [skopeo2](#provider\_skopeo2) | >= 1.1.1 |
 

--- a/container-registry/aws/ecr/examples/complete/README.md
+++ b/container-registry/aws/ecr/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/container-registry/aws/ecr/examples/complete/README.md
+++ b/container-registry/aws/ecr/examples/complete/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
 
 ## Modules
 

--- a/container-registry/aws/ecr/examples/complete/versions.tf
+++ b/container-registry/aws/ecr/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/container-registry/aws/ecr/examples/simple/README.md
+++ b/container-registry/aws/ecr/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/container-registry/aws/ecr/examples/simple/README.md
+++ b/container-registry/aws/ecr/examples/simple/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
 
 ## Modules
 

--- a/container-registry/aws/ecr/examples/simple/versions.tf
+++ b/container-registry/aws/ecr/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/container-registry/aws/ecr/versions.tf
+++ b/container-registry/aws/ecr/versions.tf
@@ -10,7 +10,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     skopeo2 = {
       source  = "bsquare-corp/skopeo2"

--- a/kubernetes/aws/addons/efs-csi/README.md
+++ b/kubernetes/aws/addons/efs-csi/README.md
@@ -6,7 +6,7 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.22.0 |
 
@@ -14,9 +14,9 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.22.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.15.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
 
 ## Modules
 

--- a/kubernetes/aws/addons/efs-csi/README.md
+++ b/kubernetes/aws/addons/efs-csi/README.md
@@ -14,9 +14,9 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.15.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.22.0 |
 
 ## Modules
 

--- a/kubernetes/aws/addons/efs-csi/examples/complete/README.md
+++ b/kubernetes/aws/addons/efs-csi/examples/complete/README.md
@@ -30,9 +30,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.38.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/kubernetes/aws/addons/efs-csi/examples/complete/README.md
+++ b/kubernetes/aws/addons/efs-csi/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.22.0 |
@@ -30,9 +30,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.38.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
 

--- a/kubernetes/aws/addons/efs-csi/examples/complete/versions.tf
+++ b/kubernetes/aws/addons/efs-csi/examples/complete/versions.tf
@@ -37,7 +37,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/kubernetes/aws/addons/efs-csi/versions.tf
+++ b/kubernetes/aws/addons/efs-csi/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.3.0"
+      version = ">= 5.61"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -26,7 +26,6 @@
 |------|--------|---------|
 | <a name="module_aws_node_termination_handler_role"></a> [aws\_node\_termination\_handler\_role](#module\_aws\_node\_termination\_handler\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.1.0 |
 | <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.24.2 |
-| <a name="module_eks_aws_auth"></a> [eks\_aws\_auth](#module\_eks\_aws\_auth) | terraform-aws-modules/eks/aws//modules/aws-auth | 20.24.2 |
 
 ## Resources
 
@@ -54,7 +53,6 @@
 | [random_string.random_resources](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [aws_autoscaling_groups.groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
-| [aws_caller_identity.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) | data source |
 | [aws_iam_policy_document.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.worker_autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
@@ -114,8 +112,6 @@
 | <a name="input_instance_refresh_tag"></a> [instance\_refresh\_tag](#input\_instance\_refresh\_tag) | Instance refresh tag | `string` | n/a | yes |
 | <a name="input_instance_refresh_version"></a> [instance\_refresh\_version](#input\_instance\_refresh\_version) | Instance refresh helm chart version | `string` | n/a | yes |
 | <a name="input_kubeconfig_file"></a> [kubeconfig\_file](#input\_kubeconfig\_file) | Kubeconfig file path | `string` | n/a | yes |
-| <a name="input_map_roles_groups"></a> [map\_roles\_groups](#input\_map\_roles\_groups) | List of map roles group | <pre>list(object({<br>    rolearn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | n/a | yes |
-| <a name="input_map_users_groups"></a> [map\_users\_groups](#input\_map\_users\_groups) | List of map users group | <pre>list(object({<br>    userarn  = string<br>    username = string<br>    groups   = list(string)<br>  }))</pre> | n/a | yes |
 | <a name="input_name"></a> [name](#input\_name) | AWS EKS service name | `string` | `"armonik-eks"` | no |
 | <a name="input_node_selector"></a> [node\_selector](#input\_node\_selector) | Node selector for pods of EKS system | `any` | `{}` | no |
 | <a name="input_profile"></a> [profile](#input\_profile) | Profile of AWS credentials to deploy Terraform sources | `string` | n/a | yes |

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -14,18 +14,19 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.13.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.15.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_node_termination_handler_role"></a> [aws\_node\_termination\_handler\_role](#module\_aws\_node\_termination\_handler\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.1.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 19.16.0 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.24.2 |
+| <a name="module_eks_aws_auth"></a> [eks\_aws\_auth](#module\_eks\_aws\_auth) | terraform-aws-modules/eks/aws//modules/aws-auth | 20.24.2 |
 
 ## Resources
 

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -14,9 +14,9 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.15.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.75.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.16.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.33.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 | <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -14,18 +14,18 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.75.1 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | 2.16.1 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.33.0 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.13.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_aws_node_termination_handler_role"></a> [aws\_node\_termination\_handler\_role](#module\_aws\_node\_termination\_handler\_role) | terraform-aws-modules/iam/aws//modules/iam-assumable-role-with-oidc | 4.1.0 |
-| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.24.2 |
+| <a name="module_eks"></a> [eks](#module\_eks) | terraform-aws-modules/eks/aws | 20.29.0 |
 
 ## Resources
 

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |

--- a/kubernetes/aws/eks/examples/complete/README.md
+++ b/kubernetes/aws/eks/examples/complete/README.md
@@ -30,9 +30,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/kubernetes/aws/eks/examples/complete/README.md
+++ b/kubernetes/aws/eks/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.21.1 |
@@ -30,9 +30,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/kubernetes/aws/eks/examples/complete/main.tf
+++ b/kubernetes/aws/eks/examples/complete/main.tf
@@ -63,8 +63,6 @@ module "eks" {
   instance_refresh_tag                                     = "v1.19.0"
   instance_refresh_version                                 = "0.21.0"
   kubeconfig_file                                          = "generated/kubeconfig"
-  map_roles_groups                                         = []
-  map_users_groups                                         = []
   vpc_id                                                   = data.aws_vpc.default.id
   vpc_pods_subnet_ids                                      = data.aws_subnets.subnets.ids
   vpc_private_subnet_ids                                   = data.aws_subnets.subnets.ids

--- a/kubernetes/aws/eks/examples/complete/versions.tf
+++ b/kubernetes/aws/eks/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/kubernetes/aws/eks/examples/simple/README.md
+++ b/kubernetes/aws/eks/examples/simple/README.md
@@ -30,9 +30,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/kubernetes/aws/eks/examples/simple/README.md
+++ b/kubernetes/aws/eks/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.21.1 |
@@ -30,9 +30,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/kubernetes/aws/eks/examples/simple/main.tf
+++ b/kubernetes/aws/eks/examples/simple/main.tf
@@ -63,8 +63,6 @@ module "eks" {
   instance_refresh_tag                                     = "v1.19.0"
   instance_refresh_version                                 = "0.21.0"
   kubeconfig_file                                          = "generated/kubeconfig"
-  map_roles_groups                                         = []
-  map_users_groups                                         = []
   vpc_id                                                   = data.aws_vpc.default.id
   vpc_pods_subnet_ids                                      = data.aws_subnets.subnets.ids
   vpc_private_subnet_ids                                   = data.aws_subnets.subnets.ids

--- a/kubernetes/aws/eks/examples/simple/versions.tf
+++ b/kubernetes/aws/eks/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -167,17 +167,6 @@ module "eks" {
   tags         = local.tags
   cluster_tags = local.tags
 
-  # IAM
-  # used to allow other users to interact with our cluster
-  # aws_auth_roles = var.map_roles_groups
-  # aws_auth_users = concat([
-  #   {
-  #     userarn  = "arn:aws:iam::${data.aws_caller_identity.current.arn}:user/admin"
-  #     username = "admin"
-  #     groups   = ["system:masters", "system:bootstrappers", "system:nodes"]
-  #   }
-  # ], var.map_users_groups)
-
   # List of EKS managed node groups
   eks_managed_node_group_defaults = {
     enable_monitoring = true

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -123,6 +123,10 @@ module "eks" {
   # If you want to maintain the current default behavior of v19.x
   kms_key_enable_default_policy = false
 
+  # Cluster access entry
+  # To add the current caller identity as an administrator
+  enable_cluster_creator_admin_permissions = true
+
   # VPC
   subnet_ids = var.vpc_private_subnet_ids
   vpc_id     = var.vpc_id

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -223,6 +223,7 @@ module "eks" {
 module "eks_aws_auth" {
   source                    = "terraform-aws-modules/eks/aws//modules/aws-auth"
   version                   = "20.24.2"
+  create_aws_auth_configmap = !(can(coalesce(var.eks_managed_node_groups)) && can(coalesce(var.fargate_profiles)))
   manage_aws_auth_configmap = true
 
   aws_auth_roles = var.map_roles_groups

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -131,17 +131,6 @@ module "eks" {
   subnet_ids = var.vpc_private_subnet_ids
   vpc_id     = var.vpc_id
 
-  # create_aws_auth_configmap = !(can(coalesce(var.eks_managed_node_groups)) && can(coalesce(var.fargate_profiles)))
-  # Needed to add self managed node group configuration.
-  # => kubectl get cm aws-auth -n kube-system -o yaml
-  #manage_aws_auth_configmap = true
-  cluster_addons = {
-    coredns                = {}
-    eks-pod-identity-agent = {}
-    kube-proxy             = {}
-    vpc-cni                = {}
-  }
-
   # Private cluster
   cluster_endpoint_private_access = var.cluster_endpoint_private_access
 
@@ -167,11 +156,7 @@ module "eks" {
     }
   }
 
-
-  cluster_security_group_additional_rules = {
-    source_node_security_group = true
-  }
-
+  cluster_additional_security_group_ids = [module.eks.node_security_group_id]
 
   cluster_encryption_config = {
     provider_key_arn = var.cluster_encryption_config

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -1,6 +1,3 @@
-# Current account
-data "aws_caller_identity" "current" {}
-
 data "aws_region" "current" {}
 
 # Available zones
@@ -218,20 +215,4 @@ module "eks" {
   eks_managed_node_groups  = local.eks_managed_node_groups
   self_managed_node_groups = local.self_managed_node_groups
   fargate_profiles         = local.fargate_profiles
-}
-
-module "eks_aws_auth" {
-  source                    = "terraform-aws-modules/eks/aws//modules/aws-auth"
-  version                   = "20.24.2"
-  create_aws_auth_configmap = !(can(coalesce(var.eks_managed_node_groups)) && can(coalesce(var.fargate_profiles)))
-  manage_aws_auth_configmap = true
-
-  aws_auth_roles = var.map_roles_groups
-  aws_auth_users = concat([
-    {
-      userarn  = "arn:aws:iam::${data.aws_caller_identity.current.arn}:user/admin"
-      username = "admin"
-      groups   = ["system:masters", "system:bootstrappers", "system:nodes"]
-    }
-  ], var.map_users_groups)
 }

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -112,7 +112,7 @@ locals {
 
 module "eks" {
   source          = "terraform-aws-modules/eks/aws"
-  version         = "20.24.2"
+  version         = "20.29.0"
   create          = true
   cluster_name    = var.name
   cluster_version = var.cluster_version

--- a/kubernetes/aws/eks/main.tf
+++ b/kubernetes/aws/eks/main.tf
@@ -135,6 +135,12 @@ module "eks" {
   # Needed to add self managed node group configuration.
   # => kubectl get cm aws-auth -n kube-system -o yaml
   #manage_aws_auth_configmap = true
+  cluster_addons = {
+    coredns                = {}
+    eks-pod-identity-agent = {}
+    kube-proxy             = {}
+    vpc-cni                = {}
+  }
 
   # Private cluster
   cluster_endpoint_private_access = var.cluster_endpoint_private_access
@@ -160,6 +166,12 @@ module "eks" {
       self        = true
     }
   }
+
+
+  cluster_security_group_additional_rules = {
+    source_node_security_group = true
+  }
+
 
   cluster_encryption_config = {
     provider_key_arn = var.cluster_encryption_config

--- a/kubernetes/aws/eks/variables.tf
+++ b/kubernetes/aws/eks/variables.tf
@@ -309,25 +309,6 @@ variable "ebs_kms_key_id" {
   type        = string
 }
 
-# Map roles
-variable "map_roles_groups" {
-  description = "List of map roles group"
-  type = list(object({
-    rolearn  = string
-    username = string
-    groups   = list(string)
-  }))
-}
-
-# Map users
-variable "map_users_groups" {
-  description = "List of map users group"
-  type = list(object({
-    userarn  = string
-    username = string
-    groups   = list(string)
-  }))
-}
 # List of self managed node groups
 variable "self_managed_node_groups" {
   description = "List of self managed node groups"

--- a/kubernetes/aws/eks/versions.tf
+++ b/kubernetes/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.3.0"
+      version = ">= 5.61"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/monitoring/aws/cloudwatch-log-group/README.md
+++ b/monitoring/aws/cloudwatch-log-group/README.md
@@ -10,7 +10,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/monitoring/aws/cloudwatch-log-group/README.md
+++ b/monitoring/aws/cloudwatch-log-group/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/monitoring/aws/cloudwatch-log-group/versions.tf
+++ b/monitoring/aws/cloudwatch-log-group/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.3.0"
+      version = ">= 5.61"
     }
   }
 }

--- a/networking/aws/vpc/README.md
+++ b/networking/aws/vpc/README.md
@@ -18,13 +18,13 @@ This module creates an AWS VPC with these constraints:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/networking/aws/vpc/README.md
+++ b/networking/aws/vpc/README.md
@@ -24,7 +24,7 @@ This module creates an AWS VPC with these constraints:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/networking/aws/vpc/examples/complete/README.md
+++ b/networking/aws/vpc/examples/complete/README.md
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpc/examples/complete/README.md
+++ b/networking/aws/vpc/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.1 |
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpc/examples/complete/versions.tf
+++ b/networking/aws/vpc/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/networking/aws/vpc/examples/simple/README.md
+++ b/networking/aws/vpc/examples/simple/README.md
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpc/examples/simple/README.md
+++ b/networking/aws/vpc/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.1 |
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpc/examples/simple/versions.tf
+++ b/networking/aws/vpc/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/networking/aws/vpc/versions.tf
+++ b/networking/aws/vpc/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
   }
 }

--- a/networking/aws/vpce/README.md
+++ b/networking/aws/vpce/README.md
@@ -49,7 +49,7 @@ Give for each endpoint object to be created the following information (variable 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/networking/aws/vpce/README.md
+++ b/networking/aws/vpce/README.md
@@ -43,13 +43,13 @@ Give for each endpoint object to be created the following information (variable 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/networking/aws/vpce/examples/complete/README.md
+++ b/networking/aws/vpce/examples/complete/README.md
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpce/examples/complete/README.md
+++ b/networking/aws/vpce/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.1 |
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpce/examples/complete/versions.tf
+++ b/networking/aws/vpce/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/networking/aws/vpce/examples/simple/README.md
+++ b/networking/aws/vpce/examples/simple/README.md
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpce/examples/simple/README.md
+++ b/networking/aws/vpce/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.1 |
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/networking/aws/vpce/examples/simple/versions.tf
+++ b/networking/aws/vpce/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/networking/aws/vpce/versions.tf
+++ b/networking/aws/vpce/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
   }
 }

--- a/security/aws/credentials/README.md
+++ b/security/aws/credentials/README.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4.3 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 5.4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.4.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
 
 ## Modules
 

--- a/security/aws/credentials/README.md
+++ b/security/aws/credentials/README.md
@@ -5,14 +5,14 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
-| <a name="requirement_random"></a> [random](#requirement\_random) | >= 5.4.0 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.4.3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.0 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.4.3 |
 
 ## Modules
 

--- a/security/aws/kms/README.md
+++ b/security/aws/kms/README.md
@@ -12,7 +12,7 @@ AWS Key Management Service (AWS KMS) lets you create, manage, and control crypto
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/security/aws/kms/README.md
+++ b/security/aws/kms/README.md
@@ -6,13 +6,13 @@ AWS Key Management Service (AWS KMS) lets you create, manage, and control crypto
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/security/aws/kms/examples/complete/README.md
+++ b/security/aws/kms/examples/complete/README.md
@@ -22,7 +22,7 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -30,9 +30,9 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.38.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
 
 ## Modules
 

--- a/security/aws/kms/examples/complete/README.md
+++ b/security/aws/kms/examples/complete/README.md
@@ -30,9 +30,9 @@ Note that this example may create resources which will incur monetary charges on
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.38.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/security/aws/kms/examples/complete/versions.tf
+++ b/security/aws/kms/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/security/aws/kms/versions.tf
+++ b/security/aws/kms/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
   }
 }

--- a/storage/aws/efs/README.md
+++ b/storage/aws/efs/README.md
@@ -6,13 +6,13 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/storage/aws/efs/README.md
+++ b/storage/aws/efs/README.md
@@ -12,7 +12,7 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/storage/aws/efs/examples/complete/README.md
+++ b/storage/aws/efs/examples/complete/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/efs/examples/complete/README.md
+++ b/storage/aws/efs/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/efs/examples/complete/versions.tf
+++ b/storage/aws/efs/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/efs/examples/simple/README.md
+++ b/storage/aws/efs/examples/simple/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/efs/examples/simple/README.md
+++ b/storage/aws/efs/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/efs/examples/simple/versions.tf
+++ b/storage/aws/efs/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/efs/versions.tf
+++ b/storage/aws/efs/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
   }
 }

--- a/storage/aws/elasticache/README.md
+++ b/storage/aws/elasticache/README.md
@@ -8,13 +8,13 @@ Amazon ElastiCache is a fully managed, Redis- and Memcached-compatible service d
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/storage/aws/elasticache/README.md
+++ b/storage/aws/elasticache/README.md
@@ -14,7 +14,7 @@ Amazon ElastiCache is a fully managed, Redis- and Memcached-compatible service d
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/storage/aws/elasticache/examples/complete/README.md
+++ b/storage/aws/elasticache/examples/complete/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/elasticache/examples/complete/README.md
+++ b/storage/aws/elasticache/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/elasticache/examples/complete/versions.tf
+++ b/storage/aws/elasticache/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/elasticache/examples/simple/README.md
+++ b/storage/aws/elasticache/examples/simple/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/elasticache/examples/simple/README.md
+++ b/storage/aws/elasticache/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/elasticache/examples/simple/versions.tf
+++ b/storage/aws/elasticache/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/elasticache/versions.tf
+++ b/storage/aws/elasticache/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
   }
 }

--- a/storage/aws/mq/README.md
+++ b/storage/aws/mq/README.md
@@ -16,9 +16,9 @@ Amazon MQ is a managed message broker service for Apache ActiveMQ and RabbitMQ t
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
 
 ## Modules
 

--- a/storage/aws/mq/README.md
+++ b/storage/aws/mq/README.md
@@ -8,7 +8,7 @@ Amazon MQ is a managed message broker service for Apache ActiveMQ and RabbitMQ t
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.7.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
 
@@ -16,9 +16,9 @@ Amazon MQ is a managed message broker service for Apache ActiveMQ and RabbitMQ t
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | 2.32.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.6.3 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/complete/activemq/README.md
+++ b/storage/aws/mq/examples/complete/activemq/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/complete/activemq/README.md
+++ b/storage/aws/mq/examples/complete/activemq/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/complete/activemq/versions.tf
+++ b/storage/aws/mq/examples/complete/activemq/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/mq/examples/complete/rabbitmq/README.md
+++ b/storage/aws/mq/examples/complete/rabbitmq/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/complete/rabbitmq/README.md
+++ b/storage/aws/mq/examples/complete/rabbitmq/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/complete/rabbitmq/versions.tf
+++ b/storage/aws/mq/examples/complete/rabbitmq/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/mq/examples/simple/activemq/README.md
+++ b/storage/aws/mq/examples/simple/activemq/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/simple/activemq/README.md
+++ b/storage/aws/mq/examples/simple/activemq/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/simple/activemq/versions.tf
+++ b/storage/aws/mq/examples/simple/activemq/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/mq/examples/simple/rabbitmq/README.md
+++ b/storage/aws/mq/examples/simple/rabbitmq/README.md
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/simple/rabbitmq/README.md
+++ b/storage/aws/mq/examples/simple/rabbitmq/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 
@@ -28,9 +28,9 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
 
 ## Modules
 

--- a/storage/aws/mq/examples/simple/rabbitmq/versions.tf
+++ b/storage/aws/mq/examples/simple/rabbitmq/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     null = {
       source  = "hashicorp/null"

--- a/storage/aws/mq/versions.tf
+++ b/storage/aws/mq/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.4.0"
+      version = ">= 5.61"
     }
     random = {
       source  = "hashicorp/random"

--- a/storage/aws/s3/README.md
+++ b/storage/aws/s3/README.md
@@ -13,13 +13,13 @@ This module creates an AWS S3 bucket with these constraints:
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.3.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.3.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
 
 ## Modules
 

--- a/storage/aws/s3/README.md
+++ b/storage/aws/s3/README.md
@@ -19,7 +19,7 @@ This module creates an AWS S3 bucket with these constraints:
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
 
 ## Modules
 

--- a/storage/aws/s3/examples/complete/README.md
+++ b/storage/aws/s3/examples/complete/README.md
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
 
 ## Modules
 

--- a/storage/aws/s3/examples/complete/README.md
+++ b/storage/aws/s3/examples/complete/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.1 |
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.4.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.3 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.2 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/storage/aws/s3/examples/complete/versions.tf
+++ b/storage/aws/s3/examples/complete/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/storage/aws/s3/examples/simple/README.md
+++ b/storage/aws/s3/examples/simple/README.md
@@ -20,7 +20,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.4.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | ~> 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | ~> 3.5.1 |
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.4.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
-| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
-| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
+| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
+| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
+| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
 
 ## Modules
 

--- a/storage/aws/s3/examples/simple/README.md
+++ b/storage/aws/s3/examples/simple/README.md
@@ -29,10 +29,10 @@ terraform destroy
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | 5.69.0 |
-| <a name="provider_external"></a> [external](#provider\_external) | 2.3.4 |
-| <a name="provider_null"></a> [null](#provider\_null) | 3.2.3 |
-| <a name="provider_random"></a> [random](#provider\_random) | 3.5.1 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 5.61 |
+| <a name="provider_external"></a> [external](#provider\_external) | ~> 2.3.1 |
+| <a name="provider_null"></a> [null](#provider\_null) | ~> 3.2.1 |
+| <a name="provider_random"></a> [random](#provider\_random) | ~> 3.5.1 |
 
 ## Modules
 

--- a/storage/aws/s3/examples/simple/versions.tf
+++ b/storage/aws/s3/examples/simple/versions.tf
@@ -9,7 +9,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.4.0"
+      version = "~> 5.61"
     }
     external = {
       source  = "hashicorp/external"

--- a/storage/aws/s3/versions.tf
+++ b/storage/aws/s3/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.3.0"
+      version = ">= 5.61"
     }
   }
 }


### PR DESCRIPTION
# Motivation

The current version of the terraform eks used doesn't support a lot of functionnalities needed for the integration of a windows node.

# Description

We update the eks module to the versoion 20.24.2



# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.