### PR TITLE
feat: Export localhost ArmoniK logs to an S3 bucket 

### DIFF
--- a/monitoring/onpremise/fluent-bit/README.md
+++ b/monitoring/onpremise/fluent-bit/README.md
@@ -25,12 +25,14 @@ No modules.
 | [kubernetes_config_map.fluent_bit_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_config_map.fluent_bit_envvars_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/config_map) | resource |
 | [kubernetes_daemonset.fluent_bit](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/daemonset) | resource |
+| [kubernetes_secret.aws_auth_config](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_service_account.fluent_bit](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
+| <a name="input_aws"></a> [aws](#input\_aws) | AWS user for logs, prefer to pass them through env('AWS\_*') in your parameters.tfvars | <pre>object({<br>    aws_secret_access_key = optional(string, "")<br>    aws_access_id         = optional(string, "")<br>    aws_session_token     = optional(string, "")<br>  })</pre> | `{}` | no |
 | <a name="input_cloudwatch"></a> [cloudwatch](#input\_cloudwatch) | CloudWatch info | `any` | `{}` | no |
 | <a name="input_fluent_bit"></a> [fluent\_bit](#input\_fluent\_bit) | Parameters of Fluent bit | <pre>object({<br>    container_name                     = string<br>    image                              = string<br>    tag                                = string<br>    is_daemonset                       = bool<br>    http_server                        = string<br>    http_port                          = string<br>    read_from_head                     = string<br>    read_from_tail                     = string<br>    image_pull_secrets                 = string<br>    parser                             = string<br>    fluent_bit_state_hostpath          = string # path = "/var/log/fluent-bit/state" for GCP Autopilot | path = "/var/fluent-bit/state" for localhost, AWS EKS, GCP GKE<br>    var_lib_docker_containers_hostpath = string # path = "/var/log/lib/docker/containers" for GCP Autopilot | path = "/var/lib/docker/containers" for localhost, AWS EKS, GCP GKE<br>    run_log_journal_hostpath           = string # path = "/var/log/run/log/journal" -for GCP Autopilot | path = "/run/log/journal" for localhost, AWS EKS, GCP GKE<br>  })</pre> | n/a | yes |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK monitoring | `string` | n/a | yes |

--- a/monitoring/onpremise/fluent-bit/aws.tf
+++ b/monitoring/onpremise/fluent-bit/aws.tf
@@ -1,0 +1,13 @@
+resource "kubernetes_secret" "aws_auth_config" {
+  metadata {
+    name      = "aws-auth-configmap"
+    namespace = var.namespace
+  }
+  data = {
+    "credentials" = templatefile("${path.module}/configs/service/aws.conf", {
+      access_key_id     = var.aws.aws_access_id,
+      secret_access_key = var.aws.aws_secret_access_key,
+      session_token     = var.aws.aws_session_token
+    })
+  }
+}

--- a/monitoring/onpremise/fluent-bit/configs/output/output-s3.conf
+++ b/monitoring/onpremise/fluent-bit/configs/output/output-s3.conf
@@ -1,11 +1,11 @@
 [OUTPUT]
     Name                         s3
-    Match                        s3-application.*
+    Match                        *
     bucket                       ${AWS_S3_NAME}
     region                       ${AWS_REGION_S3}
     total_file_size              1M
     compression                  gzip
-    s3_key_format                /${PREFIX}/%Y_%m_%d_%H/$TAG[4]_$INDEX.gz
+    s3_key_format                ${S3_KEY_FORMAT}
     s3_key_format_tag_delimiters .
     upload_timeout               1m
     use_put_object               On

--- a/monitoring/onpremise/fluent-bit/configs/service/aws.conf
+++ b/monitoring/onpremise/fluent-bit/configs/service/aws.conf
@@ -1,0 +1,4 @@
+[default]
+aws_access_key_id = ${access_key_id}
+aws_secret_access_key = ${secret_access_key}
+aws_session_token = ${session_token}

--- a/monitoring/onpremise/fluent-bit/envvars-configmap.tf
+++ b/monitoring/onpremise/fluent-bit/envvars-configmap.tf
@@ -17,7 +17,7 @@ resource "kubernetes_config_map" "fluent_bit_envvars_config" {
     APPLICATION_CLOUDWATCH_AUTO_CREATE_LOG_GROUP = (local.cloudwatch_name == "" && local.cloudwatch_enabled)
     AWS_S3_NAME                                  = local.s3_name
     AWS_REGION_S3                                = local.s3_region
-    PREFIX                                       = local.s3_prefix
+    S3_KEY_FORMAT                                = local.s3_key_format
     PARSER                                       = local.fluent_bit_parser
   }
 }

--- a/monitoring/onpremise/fluent-bit/locals.tf
+++ b/monitoring/onpremise/fluent-bit/locals.tf
@@ -28,8 +28,8 @@ locals {
   cloudwatch_enabled = tobool(try(var.cloudwatch.enabled, false))
 
   #S3
-  s3_name    = try(var.s3.name, "armonik-logs")
-  s3_region  = try(var.s3.region, "eu-west-3")
-  s3_prefix  = try(var.s3.prefix, "main")
-  s3_enabled = tobool(try(var.s3.enabled, false))
+  s3_name       = try(var.s3.name, "armonik-logs")
+  s3_region     = try(var.s3.region, "eu-west-3")
+  s3_key_format = try(var.s3.s3_key_format, "/main/$TAG[4]_$UUID")
+  s3_enabled    = tobool(try(var.s3.enabled, false))
 }

--- a/monitoring/onpremise/fluent-bit/main.tf
+++ b/monitoring/onpremise/fluent-bit/main.tf
@@ -93,6 +93,11 @@ resource "kubernetes_daemonset" "fluent_bit" {
             mount_path = "/fluent-bit/etc/"
             read_only  = true
           }
+          volume_mount {
+            name       = "aws-auth-config"
+            mount_path = "/root/.aws"
+            read_only  = true
+          }
         }
         # volume {
         #   name = "fluentbitstate"
@@ -128,6 +133,12 @@ resource "kubernetes_daemonset" "fluent_bit" {
           name = "fluent-bit-config"
           config_map {
             name = kubernetes_config_map.fluent_bit_config.metadata[0].name
+          }
+        }
+        volume {
+          name = "aws-auth-config"
+          secret {
+            secret_name = kubernetes_secret.aws_auth_config.metadata[0].name
           }
         }
         host_network                     = false

--- a/monitoring/onpremise/fluent-bit/variables.tf
+++ b/monitoring/onpremise/fluent-bit/variables.tf
@@ -32,6 +32,16 @@ variable "s3" {
   default     = {}
 }
 
+variable "aws" {
+  description = "AWS user for logs, prefer to pass them through env('AWS_*') in your parameters.tfvars"
+  type = object({
+    aws_secret_access_key = optional(string, "")
+    aws_access_id         = optional(string, "")
+    aws_session_token     = optional(string, "")
+  })
+  default = {}
+}
+
 # Fluent-bit
 variable "fluent_bit" {
   description = "Parameters of Fluent bit"


### PR DESCRIPTION
# Motivation

The logs collected by Fluentbit can be read through Seq but there was no way of exporting them for later analysis for local host deployments of ArmoniK. This PR aims to change that, and also generalize the naming scheme of the log files so as to make it easier to look through them. Which is an absolute necessity for the ArmoniK bench team because of the need to look at past runs.

# Description

Made it possible to provide AWS credentials to Fluentbit to enable AWS on localhost (it already uses EKS when using the AWS deployment), to specify a format of the log files as a tfvar. 

# Testing

Tested log dumping onto the "armonik-logs-testing" bucket. 

# Impact

Potential impact on FluentBit but it would be very minimal.

# Additional Information

You need to allow PutObject on the bucket that you choose to dump logs to.

```json
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "WriteFromS3",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::armonik-logs-testing/*"
        }
    ]
}
```

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.