### PR TITLE
fix: quoting marks missing in partition in database cronjob

### DIFF
--- a/armonik/partitions-in-database-cron.tf
+++ b/armonik/partitions-in-database-cron.tf
@@ -174,9 +174,9 @@ resource "kubernetes_cron_job_v1" "partitions_in_database" {
 locals {
   script_cron = <<EOF
 #!/bin/bash
-export nbElements=$(mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource&directConnection=true --eval 'db.PartitionData.countDocuments()' --quiet)
+export nbElements=$(mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password "mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource&directConnection=true" --eval 'db.PartitionData.countDocuments()' --quiet)
 if [[ $nbElements != ${length(local.partition_names)} ]]; then
-  mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource&directConnection=true --eval 'db.PartitionData.insertMany(${jsonencode(local.partitions_data)})'
+  mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password "mongodb://$MongoDB__Host:$MongoDB__Port/database?authSource=$MongoDB__AuthSource&directConnection=true" --eval 'db.PartitionData.insertMany(${jsonencode(local.partitions_data)})'
 fi
 EOF
 }


### PR DESCRIPTION
# Motivation

Next to #168, partitions-in-database cron job was in failed status due to missing quoting mark on the connection string, thus leading shell to interprete a '&' in a shell way rather than in a URL way.

# Description

Simply quote marks MongoDB connection string in partition-in-database command.

# Testing

Correction tested on localhost.

# Impact

Enables cron job to attain Completed status again.

# Additional Information

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [X] I have thoroughly tested my modifications and added tests when necessary.
- [X] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.