### PR TITLE
feat: Added SQS support to ArmoniK.Infra

### DIFF
--- a/service-account/aws/main.tf
+++ b/service-account/aws/main.tf
@@ -1,0 +1,45 @@
+
+
+locals {
+  prefix   = var.prefix
+  tags     = merge(var.tags, { module = "aws-service-account" })
+  oidc_arn = var.oidc_provider_arn
+  oidc_url = trimprefix(var.oidc_issuer_url, "https://")
+}
+
+resource "aws_iam_role" "armonik" {
+  name = "${local.prefix}-eks-pod-identity-${var.name}"
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.oidc_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.oidc_url}:aud" = "sts.amazonaws.com"
+            "${local.oidc_url}:sub" = [
+              "system:serviceaccount:${var.namespace}:${var.name}",
+            ]
+          }
+        }
+      }
+    ]
+  })
+  tags = local.tags
+}
+
+resource "kubernetes_service_account" "armonik" {
+  metadata {
+    name      = var.name
+    namespace = var.namespace
+
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.armonik.arn
+    }
+  }
+  automount_service_account_token = var.automount_token
+}

--- a/service-account/aws/outputs.tf
+++ b/service-account/aws/outputs.tf
@@ -1,0 +1,4 @@
+output "service_account_iam_role_name" {
+  description = "name of the IAM role associated to the created Kubernetes service account"
+  value       = aws_iam_role.armonik.name
+}

--- a/service-account/aws/variables.tf
+++ b/service-account/aws/variables.tf
@@ -1,0 +1,38 @@
+variable "prefix" {
+  description = "Prefix to use for service account related resources"
+  type        = string
+}
+
+# Tags
+variable "tags" {
+  description = "Tags for resource"
+  type        = map(string)
+  default     = {}
+}
+
+variable "namespace" {
+  description = "Namespace of ArmoniK service account related resources"
+  type        = string
+  default     = "armonik"
+}
+
+variable "name" {
+  description = "Name of the service account to create"
+  type        = string
+}
+
+variable "automount_token" {
+  description = "To enable automatic mounting of the Kubernetes service account token."
+  type        = bool
+  default     = true
+}
+
+variable "oidc_provider_arn" {
+  description = "ARN of the OIDC provider"
+  type        = string
+}
+
+variable "oidc_issuer_url" {
+  description = "URL of the OIDC issuer"
+  type        = string
+}

--- a/service-account/aws/versions.tf
+++ b/service-account/aws/versions.tf
@@ -1,0 +1,13 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.61"
+    }
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.7.1"
+    }
+  }
+}

--- a/storage/aws/s3/README.md
+++ b/storage/aws/s3/README.md
@@ -29,6 +29,8 @@ No modules.
 
 | Name | Type |
 |------|------|
+| [aws_iam_policy.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy_attachment.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
 | [aws_s3_bucket.s3_bucket](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_acl.acl](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_acl) | resource |
 | [aws_s3_bucket_ownership_controls.ownership](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_ownership_controls) | resource |
@@ -39,6 +41,7 @@ No modules.
 | [aws_iam_policy_document.combined](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.deny_insecure_transport](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.require_latest_tls](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.s3](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 
 ## Inputs
 
@@ -59,6 +62,7 @@ No modules.
 | <a name="input_ownership"></a> [ownership](#input\_ownership) | Object ownership | `string` | `"BucketOwnerPreferred"` | no |
 | <a name="input_policy"></a> [policy](#input\_policy) | Text of the policy | `string` | `null` | no |
 | <a name="input_restrict_public_buckets"></a> [restrict\_public\_buckets](#input\_restrict\_public\_buckets) | Whether Amazon S3 should restrict public bucket policies for this bucket | `bool` | `true` | no |
+| <a name="input_role_name"></a> [role\_name](#input\_role\_name) | Name of the IAM role to give the S3 permissions to | `string` | `""` | no |
 | <a name="input_sse_algorithm"></a> [sse\_algorithm](#input\_sse\_algorithm) | SSE algorithm to encrypt S3 object data | `string` | `"aws:kms"` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | Tags for resource | `any` | `{}` | no |
 | <a name="input_versioning"></a> [versioning](#input\_versioning) | Enable or disable versioning | `string` | `"Disabled"` | no |

--- a/storage/aws/s3/variables.tf
+++ b/storage/aws/s3/variables.tf
@@ -115,3 +115,9 @@ variable "adapter_absolute_path" {
   type        = string
   default     = "/adapters/object/s3/ArmoniK.Core.Adapters.S3.dll"
 }
+
+variable "role_name" {
+  description = "Name of the IAM role to give the S3 permissions to"
+  type        = string
+  default     = ""
+}

--- a/storage/aws/sqs/main.tf
+++ b/storage/aws/sqs/main.tf
@@ -1,0 +1,39 @@
+locals {
+  prefix = var.prefix
+  region = var.region
+  tags   = merge(var.tags, { module = "amazon-sqs" })
+}
+
+
+data "aws_iam_policy_document" "sqs" {
+  statement {
+    sid = "SqsAdmin"
+    actions = [
+      "sqs:CreateQueue",
+      "sqs:DeleteQueue",
+      "sqs:ListQueues",
+      "sqs:GetQueueAttributes",
+      "sqs:PurgeQueue",
+      "sqs:GetQueueUrl",
+      "sqs:ReceiveMessage",
+      "sqs:SendMessage",
+      "sqs:DeleteMessage",
+      "sqs:ChangeMessageVisibility"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:sqs:::${local.prefix}*"]
+  }
+}
+
+resource "aws_iam_policy" "sqs" {
+  name_prefix = "${local.prefix}-sqs-admin"
+  description = "Policy for allowing SQS admin access"
+  policy      = data.aws_iam_policy_document.sqs.json
+  tags        = local.tags
+}
+
+resource "aws_iam_policy_attachment" "sqs" {
+  name       = "${local.prefix}-sqs"
+  roles      = [var.service_account_role_name]
+  policy_arn = aws_iam_policy.sqs.arn
+}

--- a/storage/aws/sqs/outputs.tf
+++ b/storage/aws/sqs/outputs.tf
@@ -1,0 +1,9 @@
+output "env" {
+  description = "Environment variables to pass to ArmoniK.Core"
+  value = {
+    "Components__QueueAdaptorSettings__ClassName"           = "ArmoniK.Core.Adapters.SQS.QueueBuilder"
+    "Components__QueueAdaptorSettings__AdapterAbsolutePath" = "/adapters/queue/sqs/ArmoniK.Core.Adapters.SQS.dll"
+    "SQS__ServiceURL"                                       = "https://sqs.${local.region}.amazonaws.com"
+    "SQS__Prefix"                                           = local.prefix
+  }
+}

--- a/storage/aws/sqs/variables.tf
+++ b/storage/aws/sqs/variables.tf
@@ -1,0 +1,20 @@
+variable "region" {
+  description = "Region"
+  type        = string
+}
+
+variable "prefix" {
+  description = "Prefix to use for SQS queues"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags for resource"
+  type        = map(string)
+  default     = {}
+}
+
+variable "service_account_role_name" {
+  description = "Name of the IAM role to give the SQS permissions to"
+  type        = string
+}

--- a/storage/aws/sqs/versions.tf
+++ b/storage/aws/sqs/versions.tf
@@ -1,0 +1,9 @@
+terraform {
+  required_version = ">= 1.0"
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.61"
+    }
+  }
+}


### PR DESCRIPTION
# Motivation

SQS was added to ArmoniK.Core but was never supported in ArmoniK.Infra.

# Description

Added an optional kubernetes service account that can be associated with an AWS role that has access to SQS queues, and exported certain environment variables for ArmoniK.Core to access.

# Testing

Manually tested through deployments.

# Impact

A bit intrusive in terms of ArmoniK's configuration (`parameters.tfvars`) because of the use of a service account.

# Additional Information

None.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.