### PR TITLE
fix: fluent-bit K8s enrichment

### DIFF
--- a/armonik/locals.tf
+++ b/armonik/locals.tf
@@ -59,11 +59,6 @@ locals {
   # Fluent-bit volumes
   # Please don't change below read-only permissions
   fluent_bit_volumes = {
-    fluentbitstate = {
-      mount_path = "/var/fluent-bit/state"
-      read_only  = false
-      type       = "host_path"
-    }
     varlog = {
       mount_path = "/var/log"
       read_only  = true

--- a/monitoring/onpremise/fluent-bit/configs/filter/filter-kubernetes-daemonset.conf
+++ b/monitoring/onpremise/fluent-bit/configs/filter/filter-kubernetes-daemonset.conf
@@ -14,8 +14,6 @@
     Labels              On
     K8S-Logging.Parser  On
     K8S-Logging.Exclude Off
-    Use_Kubelet         On
-    Kubelet_Port        10250
     Buffer_Size         0
 
 [FILTER]


### PR DESCRIPTION
# Motivation

Log enrichment for kubernetes metadata was not working when fluent-bit was configured on daemon-set.

# Description

Configure fluent-bit to fetch kubernetes metadata from Kupe-API instead of kubelet, which was not working.
It also remove the *unused* volume mount on the sidecar that was failing deployment on hosts without /var/fluent-bit/state/

# Testing

Tested on locahost with K3s and docker.

# Impact

Apart from fixing the bug, there is no impact.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.