### PR TITLE
feat: implem config for new tls on core

### DIFF
--- a/.github/workflows/pre-commit.yml
+++ b/.github/workflows/pre-commit.yml
@@ -11,6 +11,11 @@ jobs:
     name: Pre-commit checks
     runs-on: ubuntu-latest
     steps:
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@b9cd54a3c349d3f38e8881555d616ced269862dd # v3
+        with:
+          terraform_version: latest
+          
       - name: Configure Terraform cache dir
         run: |
           mkdir -p "$HOME/.terraform.d/plugin-cache"

--- a/storage/onpremise/mongodb-sharded/certificates.tf
+++ b/storage/onpremise/mongodb-sharded/certificates.tf
@@ -36,7 +36,7 @@ resource "tls_cert_request" "mongodb_cert_request" {
   private_key_pem = tls_private_key.mongodb_private_key.private_key_pem
   subject {
     country     = "France"
-    common_name = "127.0.0.1"
+    common_name = local.mongodb_dns
     # organization = "127.0.0.1"
   }
 }
@@ -67,6 +67,7 @@ resource "kubernetes_secret" "mongodb_certificate" {
   data = {
     "mongodb.pem" = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_private_key.mongodb_private_key.private_key_pem)
     "chain.pem"   = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_self_signed_cert.root_mongodb.cert_pem)
+    "ca.pem"      = tls_self_signed_cert.root_mongodb.cert_pem
   }
 }
 

--- a/storage/onpremise/mongodb-sharded/outputs.tf
+++ b/storage/onpremise/mongodb-sharded/outputs.tf
@@ -50,7 +50,7 @@ output "env" {
     "MongoDB__ReplicaSet"       = "rs0"
     "MongoDB__DatabaseName"     = "database"
     "MongoDB__DirectConnection" = "true"
-    "MongoDB__CAFile"           = "/mongodb/certs/chain.pem"
+    "MongoDB__CAFile"           = "/mongodb/certs/ca.pem"
     "MongoDB__Sharding"         = "true"
     "MongoDB__AuthSource"       = "admin"
   })

--- a/storage/onpremise/mongodb-sharded/secrets.tf
+++ b/storage/onpremise/mongodb-sharded/secrets.tf
@@ -35,6 +35,8 @@ resource "kubernetes_secret" "mongodb" {
     namespace = helm_release.mongodb.namespace
   }
   data = {
+    "ca.pem"           = tls_self_signed_cert.root_mongodb.cert_pem
+    "mongodb.pem"      = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_private_key.mongodb_private_key.private_key_pem)
     "chain.pem"        = format("%s\n%s", tls_locally_signed_cert.mongodb_certificate.cert_pem, tls_self_signed_cert.root_mongodb.cert_pem)
     username           = random_string.mongodb_application_user.result
     password           = random_password.mongodb_application_password.result


### PR DESCRIPTION
# Motivation

- Implement TLS connection for MongoDB in ArmoniK.Core.

# Description

- Generated custom certificates to enable TLS for MongoDB.
- Removed the use of **chain.pem** and replaced it with a standalone certificate.

# Testing

- This branch was tested with ArmoniK deployments in the following environments:
    - Localhost
    - AWS
    - GCP 

# Impact

- Secures MongoDB connections by enabling TLS in our deployments.

# Additional Information

- None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.