### PR TITLE
chore: set auto_minor_version_upgrade to true in amazon mq

### DIFF
--- a/storage/aws/mq/main.tf
+++ b/storage/aws/mq/main.tf
@@ -27,17 +27,18 @@ resource "random_password" "password" {
 }
 
 resource "aws_mq_broker" "mq" {
-  broker_name             = var.name
-  engine_type             = var.engine_type
-  engine_version          = var.engine_version
-  host_instance_type      = var.host_instance_type
-  apply_immediately       = var.apply_immediately
-  deployment_mode         = (var.engine_type == "RabbitMQ" && var.deployment_mode == "ACTIVE_STANDBY_MULTI_AZ") ? "CLUSTER_MULTI_AZ" : (var.engine_type == "ActiveMQ" && var.deployment_mode == "CLUSTER_MULTI_AZ") ? "ACTIVE_STANDBY_MULTI_AZ" : var.deployment_mode
-  storage_type            = var.engine_type == "RabbitMQ" ? "ebs" : var.deployment_mode == "ACTIVE_STANDBY_MULTI_AZ" ? "efs" : var.storage_type # only ebs is supported for RabbitMQ
-  authentication_strategy = var.engine_type == "RabbitMQ" ? "simple" : var.authentication_strategy                                              # ldap is not supported for RabbitMQ
-  publicly_accessible     = var.publicly_accessible
-  security_groups         = [aws_security_group.mq.id]
-  subnet_ids              = local.subnet_ids
+  broker_name                = var.name
+  engine_type                = var.engine_type
+  engine_version             = var.engine_version
+  host_instance_type         = var.host_instance_type
+  apply_immediately          = var.apply_immediately
+  deployment_mode            = (var.engine_type == "RabbitMQ" && var.deployment_mode == "ACTIVE_STANDBY_MULTI_AZ") ? "CLUSTER_MULTI_AZ" : (var.engine_type == "ActiveMQ" && var.deployment_mode == "CLUSTER_MULTI_AZ") ? "ACTIVE_STANDBY_MULTI_AZ" : var.deployment_mode
+  storage_type               = var.engine_type == "RabbitMQ" ? "ebs" : var.deployment_mode == "ACTIVE_STANDBY_MULTI_AZ" ? "efs" : var.storage_type # only ebs is supported for RabbitMQ
+  authentication_strategy    = var.engine_type == "RabbitMQ" ? "simple" : var.authentication_strategy                                              # ldap is not supported for RabbitMQ
+  publicly_accessible        = var.publicly_accessible
+  security_groups            = [aws_security_group.mq.id]
+  subnet_ids                 = local.subnet_ids
+  auto_minor_version_upgrade = true
   dynamic "configuration" {
     for_each = var.engine_type == "ActiveMQ" ? [1] : []
     content {


### PR DESCRIPTION
# Motivation

Update Active mq in AWS to 5.18 requires to set the variable auto_minor_version_upgrade to true.
In order to complete the update in the [PR -1356 : chore: update active mq version to 5.18.6 in aws](https://github.com/aneoconsulting/ArmoniK/pull/1356)

# Description

Setup the variable auto_minor_version_upgrade to true will handle the case of updating active mq version.

# Testing

The deployment should work correctly when setting the engine version of active mq to 5.18 from 5.17.6.

# Impact

Update the package will be possible.

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.