### PR TITLE
feat: add resources and activemq opts memory variables in the activemq module

### DIFF
--- a/storage/onpremise/activemq/README.md
+++ b/storage/onpremise/activemq/README.md
@@ -58,7 +58,7 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_activemq"></a> [activemq](#input\_activemq) | Parameters of ActiveMQ | <pre>object({<br>    image              = string<br>    tag                = string<br>    node_selector      = any<br>    image_pull_secrets = string<br>  })</pre> | n/a | yes |
+| <a name="input_activemq"></a> [activemq](#input\_activemq) | Parameters of ActiveMQ | <pre>object({<br>    image                = string<br>    tag                  = string<br>    node_selector        = any<br>    image_pull_secrets   = string<br>    limits               = optional(map(string))<br>    requests             = optional(map(string))<br>    activemq_opts_memory = optional(string)<br>  })</pre> | n/a | yes |
 | <a name="input_adapter_absolute_path"></a> [adapter\_absolute\_path](#input\_adapter\_absolute\_path) | The adapter's absolut path | `string` | `"/adapters/queue/amqp/ArmoniK.Core.Adapters.Amqp.dll"` | no |
 | <a name="input_adapter_class_name"></a> [adapter\_class\_name](#input\_adapter\_class\_name) | Name of the adapter's class | `string` | `"ArmoniK.Core.Adapters.Amqp.QueueBuilder"` | no |
 | <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK storage resources | `string` | n/a | yes |

--- a/storage/onpremise/activemq/main.tf
+++ b/storage/onpremise/activemq/main.tf
@@ -57,7 +57,7 @@ resource "kubernetes_deployment" "activemq" {
           image_pull_policy = "IfNotPresent"
           resources {
             requests = var.activemq.requests
-            limits  = var.activemq.limits
+            limits   = var.activemq.limits
           }
           env {
             name  = "ACTIVEMQ_OPTS_MEMORY"

--- a/storage/onpremise/activemq/main.tf
+++ b/storage/onpremise/activemq/main.tf
@@ -55,6 +55,14 @@ resource "kubernetes_deployment" "activemq" {
           name              = "activemq"
           image             = "${var.activemq.image}:${var.activemq.tag}"
           image_pull_policy = "IfNotPresent"
+          resources {
+            requests = var.activemq.requests
+            limits  = var.activemq.limits
+          }
+          env {
+            name  = "ACTIVEMQ_OPTS_MEMORY"
+            value = var.activemq.activemq_opts_memory
+          }
           volume_mount {
             name       = "activemq-storage-secret-volume"
             mount_path = "/credentials/"

--- a/storage/onpremise/activemq/variables.tf
+++ b/storage/onpremise/activemq/variables.tf
@@ -12,6 +12,9 @@ variable "activemq" {
     tag                = string
     node_selector      = any
     image_pull_secrets = string
+    limits             = optional(map(string))
+    requests           = optional(map(string))
+    activemq_opts_memory = optional(string)
   })
 }
 

--- a/storage/onpremise/activemq/variables.tf
+++ b/storage/onpremise/activemq/variables.tf
@@ -8,12 +8,12 @@ variable "namespace" {
 variable "activemq" {
   description = "Parameters of ActiveMQ"
   type = object({
-    image              = string
-    tag                = string
-    node_selector      = any
-    image_pull_secrets = string
-    limits             = optional(map(string))
-    requests           = optional(map(string))
+    image                = string
+    tag                  = string
+    node_selector        = any
+    image_pull_secrets   = string
+    limits               = optional(map(string))
+    requests             = optional(map(string))
     activemq_opts_memory = optional(string)
   })
 }


### PR DESCRIPTION
# Motivation

Customize the module of Active MQ with the resources and optional heap parameters.

# Description

I added 3 optional variables (limits, requests and activemq_opts_memory) in the active mq module. These variables will be put in the container of the active mq resource. Limits and requests contain the vCPU and memory resources and the activemq_opts_memory contains the values to be given to the heap parameters.

# Testing

The Active MQ pod should contain the correct values of the resources (limits and requests of CPU and memory) and environment variable for "ACTIVEMQ_OPTS_MEMORY".

# Impact

The user can customize more the active mq module in the setup phase.

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.