### PR TITLE
fix: do not allow mixed line endings via pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -46,6 +46,9 @@ repos:
           - "--autofix"
           - "--indent=2"
           - "--no-sort-keys"
+      - id: mixed-line-ending
+        args:
+          - "--fix=lf"
   - repo: https://github.com/norwoodj/helm-docs
     rev: v1.11.0
     hooks:


### PR DESCRIPTION
# Motivation

Avoid files mixing LF and CR/LF files ending.

# Description

Add a job in the pre-commit file to check mixed file endings.

# Testing

Properly detects files with mexed line endings.

# Impact

Does not allow to merge files with mixed line endings.

# Additional Information

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.