### PR TITLE
feat: add EBS volume provisioning support for MongoDB

### DIFF
--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -36,15 +36,21 @@
 | [aws_cloudwatch_event_rule.aws_node_termination_handler_asg](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_cloudwatch_event_rule.aws_node_termination_handler_spot](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) | resource |
 | [aws_iam_policy.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
+| [aws_iam_policy.ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy.worker_autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy) | resource |
 | [aws_iam_policy_attachment.workers_autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_policy_attachment) | resource |
+| [aws_iam_role.ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy_attachment.ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [aws_iam_role_policy_attachment.efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy_attachment) | resource |
 | [helm_release.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.cluster_autoscaler](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [helm_release.ebs_csi](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.efs_csi](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [helm_release.eni_config](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_service_account.ebs_csi_driver_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [kubernetes_service_account.ebs_csi_driver_node](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [kubernetes_service_account.efs_csi_driver_controller](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [kubernetes_service_account.efs_csi_driver_node](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
 | [null_resource.change_cni_label](https://registry.terraform.io/providers/hashicorp/null/latest/docs/resources/resource) | resource |
@@ -54,6 +60,7 @@
 | [aws_autoscaling_groups.groups](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/autoscaling_groups) | data source |
 | [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
 | [aws_iam_policy_document.aws_node_termination_handler](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.ebs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.efs_csi_driver](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.worker_autoscaling](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_region.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/region) | data source |
@@ -90,20 +97,12 @@
 | <a name="input_cluster_log_kms_key_id"></a> [cluster\_log\_kms\_key\_id](#input\_cluster\_log\_kms\_key\_id) | KMS id to encrypt/decrypt the cluster's logs | `string` | n/a | yes |
 | <a name="input_cluster_log_retention_in_days"></a> [cluster\_log\_retention\_in\_days](#input\_cluster\_log\_retention\_in\_days) | Logs retention in days | `number` | n/a | yes |
 | <a name="input_cluster_version"></a> [cluster\_version](#input\_cluster\_version) | Kubernetes version to use for the EKS cluster | `string` | n/a | yes |
+| <a name="input_csi_external_provisioner"></a> [csi\_external\_provisioner](#input\_csi\_external\_provisioner) | CSI external provisioner for both EFS and EBS | <pre>object({<br>    image = optional(string, "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner")<br>    tag   = string<br>  })</pre> | n/a | yes |
+| <a name="input_csi_liveness_probe"></a> [csi\_liveness\_probe](#input\_csi\_liveness\_probe) | CSI liveness probe for both EFS and EBS | <pre>object({<br>    image = optional(string, "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe")<br>    tag   = string<br>  })</pre> | n/a | yes |
+| <a name="input_csi_node_driver_registrar"></a> [csi\_node\_driver\_registrar](#input\_csi\_node\_driver\_registrar) | CSI node driver registrar for both EFS and EBS | <pre>object({<br>    image = optional(string, "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar")<br>    tag   = string<br>  })</pre> | n/a | yes |
+| <a name="input_ebs_csi"></a> [ebs\_csi](#input\_ebs\_csi) | Container Storage Interface for EBS volume provisioning on EKS | <pre>object({<br>    repository         = optional(string, "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/")<br>    version            = string<br>    image              = optional(string, "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver")<br>    tag                = string<br>    name               = optional(string)<br>    namespace          = optional(string)<br>    image_pull_secrets = optional(string)<br>    controller_resources = optional(object({<br>      limits = optional(object({<br>        storage = string<br>      }))<br>      requests = optional(object({<br>        storage = string<br>      }))<br>    }))<br>  })</pre> | n/a | yes |
 | <a name="input_ebs_kms_key_id"></a> [ebs\_kms\_key\_id](#input\_ebs\_kms\_key\_id) | KMS key id to encrypt/decrypt EBS | `string` | n/a | yes |
-| <a name="input_efs_csi_external_provisioner_image"></a> [efs\_csi\_external\_provisioner\_image](#input\_efs\_csi\_external\_provisioner\_image) | EFS CSI external provisioner image name | `string` | n/a | yes |
-| <a name="input_efs_csi_external_provisioner_tag"></a> [efs\_csi\_external\_provisioner\_tag](#input\_efs\_csi\_external\_provisioner\_tag) | EFS CSI external provisioner image tag | `string` | n/a | yes |
-| <a name="input_efs_csi_image"></a> [efs\_csi\_image](#input\_efs\_csi\_image) | EFS CSI image name | `string` | n/a | yes |
-| <a name="input_efs_csi_image_pull_secrets"></a> [efs\_csi\_image\_pull\_secrets](#input\_efs\_csi\_image\_pull\_secrets) | Image pull secret used to pull EFS CSI images | `string` | `null` | no |
-| <a name="input_efs_csi_liveness_probe_image"></a> [efs\_csi\_liveness\_probe\_image](#input\_efs\_csi\_liveness\_probe\_image) | EFS CSI liveness probe image name | `string` | n/a | yes |
-| <a name="input_efs_csi_liveness_probe_tag"></a> [efs\_csi\_liveness\_probe\_tag](#input\_efs\_csi\_liveness\_probe\_tag) | EFS CSI liveness probe image tag | `string` | n/a | yes |
-| <a name="input_efs_csi_name"></a> [efs\_csi\_name](#input\_efs\_csi\_name) | EFS CSI name | `string` | `null` | no |
-| <a name="input_efs_csi_namespace"></a> [efs\_csi\_namespace](#input\_efs\_csi\_namespace) | EFS CSI namespace | `string` | `null` | no |
-| <a name="input_efs_csi_node_driver_registrar_image"></a> [efs\_csi\_node\_driver\_registrar\_image](#input\_efs\_csi\_node\_driver\_registrar\_image) | EFS CSI node driver registrar image name | `string` | n/a | yes |
-| <a name="input_efs_csi_node_driver_registrar_tag"></a> [efs\_csi\_node\_driver\_registrar\_tag](#input\_efs\_csi\_node\_driver\_registrar\_tag) | EFS CSI node driver registrar image tag | `string` | n/a | yes |
-| <a name="input_efs_csi_repository"></a> [efs\_csi\_repository](#input\_efs\_csi\_repository) | EFS CSI helm repository | `string` | n/a | yes |
-| <a name="input_efs_csi_tag"></a> [efs\_csi\_tag](#input\_efs\_csi\_tag) | EFS CSI image tag | `string` | n/a | yes |
-| <a name="input_efs_csi_version"></a> [efs\_csi\_version](#input\_efs\_csi\_version) | EFS CSI helm version | `string` | n/a | yes |
+| <a name="input_efs_csi"></a> [efs\_csi](#input\_efs\_csi) | Container Storage Interface for EFS volume provisioning on EKS | <pre>object({<br>    repository         = optional(string, "https://kubernetes-sigs.github.io/aws-efs-csi-driver/")<br>    version            = string<br>    image              = optional(string, "public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver")<br>    tag                = string<br>    name               = optional(string)<br>    namespace          = optional(string)<br>    image_pull_secrets = optional(string)<br>    controller_resources = optional(object({<br>      limits = optional(object({<br>        storage = string<br>      }))<br>      requests = optional(object({<br>        storage = string<br>      }))<br>    }))<br>  })</pre> | n/a | yes |
 | <a name="input_eks_managed_node_groups"></a> [eks\_managed\_node\_groups](#input\_eks\_managed\_node\_groups) | List of EKS managed node groups | `any` | `null` | no |
 | <a name="input_fargate_profiles"></a> [fargate\_profiles](#input\_fargate\_profiles) | List of fargate profiles | `any` | `null` | no |
 | <a name="input_instance_refresh_image"></a> [instance\_refresh\_image](#input\_instance\_refresh\_image) | Instance refresh image name | `string` | n/a | yes |

--- a/kubernetes/aws/eks/ebs-csi.tf
+++ b/kubernetes/aws/eks/ebs-csi.tf
@@ -1,0 +1,322 @@
+locals {
+  # ebs CSI
+  ebs_csi = {
+    name                                  = coalesce(var.ebs_csi_name, "${var.name}-ebs-csi-driver")
+    oidc_arn                              = module.eks.oidc_provider_arn
+    oidc_url                              = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
+    namespace                             = coalesce(var.ebs_csi_namespace, "kube-system")
+    kubernetes_service_account_controller = "ebs-csi-controller"
+    kubernetes_service_account_node       = "ebs-csi-node"
+
+    tolerations = var.node_selector != {} ? [
+      for key, value in var.node_selector : {
+        key      = key
+        operator = "Equal"
+        value    = value
+        effect   = "NoSchedule"
+      }
+    ] : []
+  }
+
+  ebs_csi_controller = {
+    controller = {
+      logLevel            = 2
+      extraCreateMetadata = true
+      podAnnotations      = {}
+      resources           = var.ebs_csi_controller_resources
+      nodeSelector        = var.node_selector
+      tolerations         = local.ebs_csi.tolerations
+      affinity            = {}
+      serviceAccount = {
+        create = false
+        name   = kubernetes_service_account.ebs_csi_driver_controller.metadata[0].name
+        annotations = {
+          "app.kubernetes.io/managed-by"   = "Helm"
+          "meta.helm.sh/release-name"      = "ebs-csi"
+          "meta.helm.sh/release-namespace" = "kube-system"
+        }
+      }
+    }
+  }
+}
+
+# Allow EKS and the driver to interact with ebs
+data "aws_iam_policy_document" "ebs_csi_driver" {
+  statement {
+    actions = [
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeInstances",
+      "ec2:DescribeSnapshots",
+      "ec2:DescribeTags",
+      "ec2:DescribeVolumes",
+      "ec2:DescribeVolumesModifications"
+    ]
+    effect    = "Allow"
+    resources = ["*"]
+  }
+  statement {
+    actions = [
+      "ec2:CreateSnapshot",
+      "ec2:ModifyVolume"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:volume/*"]
+  }
+  statement {
+    actions = [
+      "ec2:AttachVolume",
+      "ec2:DetachVolume"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:instance/*"
+    ]
+  }
+  statement {
+    actions = [
+      "ec2:CreateVolume",
+      "ec2:EnableFastSnapshotRestores"
+    ]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+  }
+  statement {
+    actions = [
+      "ec2:CreateTags"
+    ]
+    effect = "Allow"
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:snapshot/*"
+    ]
+    condition {
+      test = "StringEquals"
+      values = [
+        "CreateVolume",
+        "CreateSnapshot"
+      ]
+      variable = "ec2:CreateAction"
+    }
+  }
+  statement {
+    actions = ["ec2:DeleteTags"]
+    effect  = "Allow"
+    resources = [
+      "arn:aws:ec2:*:*:volume/*",
+      "arn:aws:ec2:*:*:snapshot/*"
+    ]
+  }
+  statement {
+    actions   = ["ec2:CreateVolume"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:volume/*"]
+    condition {
+      test     = "StringLike"
+      values   = [true]
+      variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
+    }
+  }
+  statement {
+    actions   = ["ec2:CreateVolume"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:volume/*"]
+    condition {
+      test     = "StringLike"
+      values   = ["*"]
+      variable = "aws:RequestTag/CSIVolumeName"
+    }
+  }
+  statement {
+    actions   = ["ec2:DeleteVolume"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:volume/*"]
+    condition {
+      test     = "StringLike"
+      values   = [true]
+      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
+    }
+  }
+  statement {
+    actions   = ["ec2:DeleteVolume"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:volume/*"]
+    condition {
+      test     = "StringLike"
+      values   = ["*"]
+      variable = "ec2:ResourceTag/CSIVolumeName"
+    }
+  }
+  statement {
+    actions   = ["ec2:DeleteVolume"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:volume/*"]
+    condition {
+      test     = "StringLike"
+      values   = ["*"]
+      variable = "ec2:ResourceTag/kubernetes.io/created-for/pvc/name"
+    }
+  }
+  statement {
+    actions   = ["ec2:CreateSnapshot"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+    condition {
+      test     = "StringLike"
+      values   = ["*"]
+      variable = "aws:RequestTag/CSIVolumeSnapshotName"
+    }
+  }
+  statement {
+    actions   = ["ec2:CreateSnapshot"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+    condition {
+      test     = "StringLike"
+      values   = [true]
+      variable = "aws:RequestTag/ebs.csi.aws.com/cluster"
+    }
+  }
+  statement {
+    actions   = ["ec2:DeleteSnapshot"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+    condition {
+      test     = "StringLike"
+      values   = ["*"]
+      variable = "ec2:ResourceTag/CSIVolumeSnapshotName"
+    }
+  }
+  statement {
+    actions   = ["ec2:DeleteSnapshot"]
+    effect    = "Allow"
+    resources = ["arn:aws:ec2:*:*:snapshot/*"]
+    condition {
+      test     = "StringLike"
+      values   = [true]
+      variable = "ec2:ResourceTag/ebs.csi.aws.com/cluster"
+    }
+  }
+}
+
+resource "aws_iam_policy" "ebs_csi_driver" {
+  name_prefix = local.ebs_csi.name
+  description = "Policy to allow EKS and the driver to interact with EBS"
+  policy      = data.aws_iam_policy_document.ebs_csi_driver.json
+  tags        = local.tags
+}
+
+resource "aws_iam_role" "ebs_csi_driver" {
+  name = local.ebs_csi.name
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Federated = local.ebs_csi.oidc_arn
+        }
+        Action = "sts:AssumeRoleWithWebIdentity"
+        Condition = {
+          StringEquals = {
+            "${local.ebs_csi.oidc_url}:aud" = "sts.amazonaws.com"
+            "${local.ebs_csi.oidc_url}:sub" = [
+              "system:serviceaccount:${local.ebs_csi.namespace}:${local.ebs_csi.kubernetes_service_account_controller}",
+              "system:serviceaccount:${local.ebs_csi.namespace}:${local.ebs_csi.kubernetes_service_account_node}"
+            ]
+          }
+        }
+      }
+    ]
+  })
+  tags       = local.tags
+  depends_on = [aws_iam_policy.ebs_csi_driver]
+}
+
+resource "aws_iam_role_policy_attachment" "ebs_csi_driver" {
+  policy_arn = aws_iam_policy.ebs_csi_driver.arn
+  role       = aws_iam_role.ebs_csi_driver.name
+}
+
+resource "kubernetes_service_account" "ebs_csi_driver_controller" {
+  metadata {
+    name = local.ebs_csi.kubernetes_service_account_controller
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.ebs_csi_driver.arn
+    }
+    namespace = local.ebs_csi.namespace
+  }
+}
+
+resource "kubernetes_service_account" "ebs_csi_driver_node" {
+  metadata {
+    name = local.ebs_csi.kubernetes_service_account_node
+    annotations = {
+      "eks.amazonaws.com/role-arn" = aws_iam_role.ebs_csi_driver.arn
+    }
+    namespace = local.ebs_csi.namespace
+  }
+}
+
+resource "helm_release" "ebs_csi" {
+  name       = "ebs-csi"
+  namespace  = kubernetes_service_account.ebs_csi_driver_controller.metadata[0].namespace
+  chart      = "aws-ebs-csi-driver"
+  repository = var.ebs_csi_repository
+  version    = var.ebs_csi_version
+
+  set {
+    name  = "image.repository"
+    value = var.ebs_csi_image
+  }
+  set {
+    name  = "image.tag"
+    value = var.ebs_csi_tag
+  }
+  set {
+    name  = "sidecars.livenessProbe.image.repository"
+    value = var.ebs_csi_liveness_probe_image
+  }
+  set {
+    name  = "sidecars.livenessProbe.image.tag"
+    value = var.ebs_csi_liveness_probe_tag
+  }
+  set {
+    name  = "sidecars.nodeDriverRegistrar.image.repository"
+    value = var.ebs_csi_node_driver_registrar_image
+  }
+  set {
+    name  = "sidecars.nodeDriverRegistrar.image.tag"
+    value = var.ebs_csi_node_driver_registrar_tag
+  }
+  set {
+    name  = "sidecars.provisioner.image.repository"
+    value = var.ebs_csi_external_provisioner_image
+  }
+  set {
+    name  = "sidecars.provisioner.image.tag"
+    value = var.ebs_csi_external_provisioner_tag
+  }
+  dynamic "set" {
+    for_each = toset(compact([var.ebs_csi_image_pull_secrets]))
+    content {
+      name  = "imagePullSecrets"
+      value = each.key
+    }
+  }
+  set {
+    name  = "node.serviceAccount.create"
+    value = false
+  }
+  set {
+    name  = "node.serviceAccount.name"
+    value = kubernetes_service_account.ebs_csi_driver_node.metadata[0].name
+  }
+  values = [
+    yamlencode(local.ebs_csi_controller.controller)
+  ]
+  depends_on = [
+    kubernetes_service_account.ebs_csi_driver_controller,
+    kubernetes_service_account.ebs_csi_driver_node
+  ]
+}

--- a/kubernetes/aws/eks/ebs-csi.tf
+++ b/kubernetes/aws/eks/ebs-csi.tf
@@ -1,12 +1,12 @@
 locals {
   # ebs CSI
   ebs_csi = {
-    name                                  = coalesce(var.ebs_csi_name, "${var.name}-ebs-csi-driver")
+    name                                  = coalesce(var.ebs_csi.name, "${var.name}-ebs-csi-driver")
     oidc_arn                              = module.eks.oidc_provider_arn
     oidc_url                              = trimprefix(module.eks.cluster_oidc_issuer_url, "https://")
-    namespace                             = coalesce(var.ebs_csi_namespace, "kube-system")
-    kubernetes_service_account_controller = "ebs-csi-controller"
-    kubernetes_service_account_node       = "ebs-csi-node"
+    namespace                             = coalesce(var.ebs_csi.namespace, "kube-system")
+    kubernetes_service_account_controller = "ebs-csi-controller-sa"
+    kubernetes_service_account_node       = "ebs-csi-node-sa"
 
     tolerations = var.node_selector != {} ? [
       for key, value in var.node_selector : {
@@ -23,22 +23,51 @@ locals {
       logLevel            = 2
       extraCreateMetadata = true
       podAnnotations      = {}
-      resources           = var.ebs_csi_controller_resources
+      resources           = var.ebs_csi.controller_resources
       nodeSelector        = var.node_selector
       tolerations         = local.ebs_csi.tolerations
       affinity            = {}
       serviceAccount = {
         create = false
         name   = kubernetes_service_account.ebs_csi_driver_controller.metadata[0].name
-        annotations = {
-          "app.kubernetes.io/managed-by"   = "Helm"
-          "meta.helm.sh/release-name"      = "ebs-csi"
-          "meta.helm.sh/release-namespace" = "kube-system"
-        }
       }
     }
   }
 }
+
+# Simpler IAM policies
+# data "aws_iam_policy_document" "ebs_csi_driver" {
+#   statement {
+#     actions = [
+#       "ec2:CreateVolume",
+#       "ec2:AttachVolume",
+#       "ec2:DetachVolume",
+#       "ec2:DeleteVolume",
+#       "ec2:CreateSnapshot",
+#       "ec2:DeleteSnapshot",
+#       "ec2:DescribeVolumes",
+#       "ec2:DescribeSnapshots",
+#       "ec2:DescribeInstances",
+#       "ec2:DescribeAvailabilityZones",
+#       "ec2:DescribeVolumeStatus",
+#       "ec2:DescribeVolumeAttribute",
+#       "ec2:DescribeSnapshotAttribute",
+#       "ec2:DescribeInstanceAttribute",
+#       "ec2:DescribeInstanceCreditSpecifications",
+#       "ec2:DescribeVolumeTypes",
+#       "ec2:DescribeVpcAttribute",
+#       "ec2:DescribeVpcEndpoints",
+#       "ec2:DescribeVpcs",
+#       "ec2:ModifyVolume",
+#       "ec2:ModifyVolumeAttribute",
+#       "ec2:ModifyInstanceAttribute",
+#       "ec2:CreateTags",
+#       "ec2:DeleteTags"
+#     ]
+#     effect    = "Allow"
+#     resources = ["*"]
+#   }
+# }
 
 # Allow EKS and the driver to interact with ebs
 data "aws_iam_policy_document" "ebs_csi_driver" {
@@ -242,7 +271,13 @@ resource "kubernetes_service_account" "ebs_csi_driver_controller" {
   metadata {
     name = local.ebs_csi.kubernetes_service_account_controller
     annotations = {
-      "eks.amazonaws.com/role-arn" = aws_iam_role.ebs_csi_driver.arn
+      "eks.amazonaws.com/role-arn"     = aws_iam_role.ebs_csi_driver.arn
+      "app.kubernetes.io/managed-by"   = "Helm"
+      "meta.helm.sh/release-name"      = "ebs-csi"
+      "meta.helm.sh/release-namespace" = "kube-system"
+    }
+    labels = {
+      "app.kubernetes.io/managed-by" = "Helm"
     }
     namespace = local.ebs_csi.namespace
   }
@@ -262,43 +297,43 @@ resource "helm_release" "ebs_csi" {
   name       = "ebs-csi"
   namespace  = kubernetes_service_account.ebs_csi_driver_controller.metadata[0].namespace
   chart      = "aws-ebs-csi-driver"
-  repository = var.ebs_csi_repository
-  version    = var.ebs_csi_version
+  repository = var.ebs_csi.repository
+  version    = var.ebs_csi.version
 
   set {
     name  = "image.repository"
-    value = var.ebs_csi_image
+    value = var.ebs_csi.image
   }
   set {
     name  = "image.tag"
-    value = var.ebs_csi_tag
+    value = var.ebs_csi.tag
   }
   set {
     name  = "sidecars.livenessProbe.image.repository"
-    value = var.ebs_csi_liveness_probe_image
+    value = var.csi_liveness_probe.image
   }
   set {
     name  = "sidecars.livenessProbe.image.tag"
-    value = var.ebs_csi_liveness_probe_tag
+    value = var.csi_liveness_probe.tag
   }
   set {
     name  = "sidecars.nodeDriverRegistrar.image.repository"
-    value = var.ebs_csi_node_driver_registrar_image
+    value = var.csi_node_driver_registrar.image
   }
   set {
     name  = "sidecars.nodeDriverRegistrar.image.tag"
-    value = var.ebs_csi_node_driver_registrar_tag
+    value = var.csi_node_driver_registrar.tag
   }
   set {
     name  = "sidecars.provisioner.image.repository"
-    value = var.ebs_csi_external_provisioner_image
+    value = var.csi_external_provisioner.image
   }
   set {
     name  = "sidecars.provisioner.image.tag"
-    value = var.ebs_csi_external_provisioner_tag
+    value = var.csi_external_provisioner.tag
   }
   dynamic "set" {
-    for_each = toset(compact([var.ebs_csi_image_pull_secrets]))
+    for_each = toset(compact([var.ebs_csi.image_pull_secrets]))
     content {
       name  = "imagePullSecrets"
       value = each.key

--- a/kubernetes/aws/eks/examples/complete/main.tf
+++ b/kubernetes/aws/eks/examples/complete/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "timestamp" {
 }
 
 data "aws_vpc" "default" {
-  default = true
+  id = "vpc-06ea74e725b5ee5e1"
 }
 
 data "aws_subnets" "subnets" {
@@ -77,6 +77,17 @@ module "eks" {
   efs_csi_external_provisioner_tag    = "v3.4.0-eks-1-22-19"
   efs_csi_repository                  = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
   efs_csi_version                     = "2.3.0"
+
+  ebs_csi_image                       = "amazon/aws-ebs-csi-driver"
+  ebs_csi_tag                         = "v1.39.0"
+  ebs_csi_liveness_probe_image        = "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
+  ebs_csi_liveness_probe_tag          = "v2.14.0-eks-1-31-12"
+  ebs_csi_node_driver_registrar_image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
+  ebs_csi_node_driver_registrar_tag   = "v2.13.0-eks-1-31-12"
+  ebs_csi_external_provisioner_image  = "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
+  ebs_csi_external_provisioner_tag    = "v5.1.0-eks-1-31-12"
+  ebs_csi_repository                  = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/"
+  ebs_csi_version                     = "2.39.1"
 
   eks_managed_node_groups = {
     test = {

--- a/kubernetes/aws/eks/examples/complete/main.tf
+++ b/kubernetes/aws/eks/examples/complete/main.tf
@@ -17,7 +17,7 @@ resource "null_resource" "timestamp" {
 }
 
 data "aws_vpc" "default" {
-  id = "vpc-06ea74e725b5ee5e1"
+  default = true
 }
 
 data "aws_subnets" "subnets" {
@@ -67,27 +67,34 @@ module "eks" {
   vpc_pods_subnet_ids                                      = data.aws_subnets.subnets.ids
   vpc_private_subnet_ids                                   = data.aws_subnets.subnets.ids
 
-  efs_csi_image                       = "amazon/aws-efs-csi-driver"
-  efs_csi_tag                         = "v1.5.1"
-  efs_csi_liveness_probe_image        = "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
-  efs_csi_liveness_probe_tag          = "v2.9.0-eks-1-22-19"
-  efs_csi_node_driver_registrar_image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
-  efs_csi_node_driver_registrar_tag   = "v2.7.0-eks-1-22-19"
-  efs_csi_external_provisioner_image  = "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
-  efs_csi_external_provisioner_tag    = "v3.4.0-eks-1-22-19"
-  efs_csi_repository                  = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
-  efs_csi_version                     = "2.3.0"
+  efs_csi = {
+    image      = "amazon/aws-efs-csi-driver"
+    tag        = "v1.5.1"
+    repository = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
+    version    = "2.3.0"
+  }
 
-  ebs_csi_image                       = "amazon/aws-ebs-csi-driver"
-  ebs_csi_tag                         = "v1.39.0"
-  ebs_csi_liveness_probe_image        = "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
-  ebs_csi_liveness_probe_tag          = "v2.14.0-eks-1-31-12"
-  ebs_csi_node_driver_registrar_image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
-  ebs_csi_node_driver_registrar_tag   = "v2.13.0-eks-1-31-12"
-  ebs_csi_external_provisioner_image  = "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
-  ebs_csi_external_provisioner_tag    = "v5.1.0-eks-1-31-12"
-  ebs_csi_repository                  = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/"
-  ebs_csi_version                     = "2.39.1"
+  ebs_csi = {
+    image      = "amazon/aws-ebs-csi-driver"
+    tag        = "v1.39.0"
+    repository = "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/"
+    version    = "2.39.1"
+  }
+
+  csi_liveness_probe = {
+    image = "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
+    tag   = "v2.9.0-eks-1-22-19"
+  }
+
+  csi_node_driver_registrar = {
+    image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
+    tag   = "v2.7.0-eks-1-22-19"
+  }
+
+  csi_external_provisioner = {
+    image = "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
+    tag   = "v1.39.0"
+  }
 
   eks_managed_node_groups = {
     test = {

--- a/kubernetes/aws/eks/examples/complete/variables.tf
+++ b/kubernetes/aws/eks/examples/complete/variables.tf
@@ -2,7 +2,7 @@
 variable "aws_profile" {
   description = "Profile of AWS credentials to deploy Terraform sources"
   type        = string
-  default     = "default"
+  default     = "tschneider"
 }
 
 # Region

--- a/kubernetes/aws/eks/examples/complete/variables.tf
+++ b/kubernetes/aws/eks/examples/complete/variables.tf
@@ -2,7 +2,7 @@
 variable "aws_profile" {
   description = "Profile of AWS credentials to deploy Terraform sources"
   type        = string
-  default     = "tschneider"
+  default     = "default"
 }
 
 # Region

--- a/kubernetes/aws/eks/examples/simple/main.tf
+++ b/kubernetes/aws/eks/examples/simple/main.tf
@@ -67,16 +67,27 @@ module "eks" {
   vpc_pods_subnet_ids                                      = data.aws_subnets.subnets.ids
   vpc_private_subnet_ids                                   = data.aws_subnets.subnets.ids
 
-  efs_csi_image                       = "amazon/aws-efs-csi-driver"
-  efs_csi_tag                         = "v1.5.1"
-  efs_csi_liveness_probe_image        = "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe"
-  efs_csi_liveness_probe_tag          = "v2.9.0-eks-1-22-19"
-  efs_csi_node_driver_registrar_image = "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar"
-  efs_csi_node_driver_registrar_tag   = "v2.7.0-eks-1-22-19"
-  efs_csi_external_provisioner_image  = "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner"
-  efs_csi_external_provisioner_tag    = "v3.4.0-eks-1-22-19"
-  efs_csi_repository                  = "https://kubernetes-sigs.github.io/aws-efs-csi-driver/"
-  efs_csi_version                     = "2.3.0"
+  efs_csi = {
+    tag     = "v1.5.1"
+    version = "2.3.0"
+  }
+
+  ebs_csi = {
+    tag     = "v1.39.0"
+    version = "2.39.1"
+  }
+
+  csi_liveness_probe = {
+    tag = "v2.9.0-eks-1-22-19"
+  }
+
+  csi_node_driver_registrar = {
+    tag = "v2.7.0-eks-1-22-19"
+  }
+
+  csi_external_provisioner = {
+    tag = "v3.4.0-eks-1-22-19"
+  }
 
   eks_managed_node_groups = {
     test = {

--- a/kubernetes/aws/eks/variables.tf
+++ b/kubernetes/aws/eks/variables.tf
@@ -235,130 +235,69 @@ variable "eks_managed_node_groups" {
   default     = null
 }
 
-# EFS
-variable "efs_csi_image" {
-  description = "EFS CSI image name"
-  type        = string
-}
-variable "efs_csi_tag" {
-  description = "EFS CSI image tag"
-  type        = string
-}
-variable "efs_csi_liveness_probe_image" {
-  description = "EFS CSI liveness probe image name"
-  type        = string
-}
-variable "efs_csi_liveness_probe_tag" {
-  description = "EFS CSI liveness probe image tag"
-  type        = string
-}
-variable "efs_csi_node_driver_registrar_image" {
-  description = "EFS CSI node driver registrar image name"
-  type        = string
-}
-variable "efs_csi_node_driver_registrar_tag" {
-  description = "EFS CSI node driver registrar image tag"
-  type        = string
-}
-variable "efs_csi_external_provisioner_image" {
-  description = "EFS CSI external provisioner image name"
-  type        = string
-}
-variable "efs_csi_external_provisioner_tag" {
-  description = "EFS CSI external provisioner image tag"
-  type        = string
-}
-
-variable "efs_csi_name" {
-  description = "EFS CSI name"
-  type        = string
-  default     = null
-}
-variable "efs_csi_namespace" {
-  description = "EFS CSI namespace"
-  type        = string
-  default     = null
-}
-variable "efs_csi_image_pull_secrets" {
-  description = "Image pull secret used to pull EFS CSI images"
-  type        = string
-  default     = null
-}
-variable "efs_csi_repository" {
-  description = "EFS CSI helm repository"
-  type        = string
-}
-variable "efs_csi_version" {
-  description = "EFS CSI helm version"
-  type        = string
-}
-
-# EBS
-
-variable "ebs_csi_image" {
-  description = "EBS CSI image name"
-  type        = string
-}
-variable "ebs_csi_tag" {
-  description = "EBS CSI image tag"
-  type        = string
-}
-variable "ebs_csi_liveness_probe_image" {
-  description = "EBS CSI liveness probe image name"
-  type        = string
-}
-variable "ebs_csi_liveness_probe_tag" {
-  description = "EBS CSI liveness probe image tag"
-  type        = string
-}
-variable "ebs_csi_node_driver_registrar_image" {
-  description = "EBS CSI node driver registrar image name"
-  type        = string
-}
-variable "ebs_csi_node_driver_registrar_tag" {
-  description = "EBS CSI node driver registrar image tag"
-  type        = string
-}
-variable "ebs_csi_external_provisioner_image" {
-  description = "EBS CSI external provisioner image name"
-  type        = string
-}
-variable "ebs_csi_external_provisioner_tag" {
-  description = "EBS CSI external provisioner image tag"
-  type        = string
-}
-variable "ebs_csi_name" {
-  description = "EBS CSI name"
-  type        = string
-  default     = null
-}
-variable "ebs_csi_namespace" {
-  description = "EBS CSI namespace"
-  type        = string
-  default     = null
-}
-variable "ebs_csi_image_pull_secrets" {
-  description = "Image pull secret used to pull EFS CSI images"
-  type        = string
-  default     = null
-}
-variable "ebs_csi_repository" {
-  description = "EBS CSI helm repository"
-  type        = string
-}
-variable "ebs_csi_version" {
-  description = "EBS CSI helm version"
-  type        = string
-}
-variable "ebs_csi_controller_resources" {
-  description = "Resources to allocate for EBS CSI driver controller"
+variable "efs_csi" {
+  description = "Container Storage Interface for EFS volume provisioning on EKS"
   type = object({
-    limits   = optional(map(string))
-    requests = optional(map(string))
+    repository         = optional(string, "https://kubernetes-sigs.github.io/aws-efs-csi-driver/")
+    version            = string
+    image              = optional(string, "public.ecr.aws/efs-csi-driver/amazon/aws-efs-csi-driver")
+    tag                = string
+    name               = optional(string)
+    namespace          = optional(string)
+    image_pull_secrets = optional(string)
+    controller_resources = optional(object({
+      limits = optional(object({
+        storage = string
+      }))
+      requests = optional(object({
+        storage = string
+      }))
+    }))
   })
-  default = {}
 }
 
+variable "ebs_csi" {
+  description = "Container Storage Interface for EBS volume provisioning on EKS"
+  type = object({
+    repository         = optional(string, "https://kubernetes-sigs.github.io/aws-ebs-csi-driver/")
+    version            = string
+    image              = optional(string, "public.ecr.aws/ebs-csi-driver/aws-ebs-csi-driver")
+    tag                = string
+    name               = optional(string)
+    namespace          = optional(string)
+    image_pull_secrets = optional(string)
+    controller_resources = optional(object({
+      limits = optional(object({
+        storage = string
+      }))
+      requests = optional(object({
+        storage = string
+      }))
+    }))
+  })
+}
+
+variable "csi_liveness_probe" {
+  description = "CSI liveness probe for both EFS and EBS"
+  type = object({
+    image = optional(string, "public.ecr.aws/eks-distro/kubernetes-csi/livenessprobe")
+    tag   = string
+  })
+}
+variable "csi_node_driver_registrar" {
+  description = "CSI node driver registrar for both EFS and EBS"
+  type = object({
+    image = optional(string, "public.ecr.aws/eks-distro/kubernetes-csi/node-driver-registrar")
+    tag   = string
+  })
+}
+variable "csi_external_provisioner" {
+  description = "CSI external provisioner for both EFS and EBS"
+  type = object({
+    image = optional(string, "public.ecr.aws/eks-distro/kubernetes-csi/external-provisioner")
+    tag   = string
+  })
+}
 
 # Encryption keys
 variable "cluster_log_kms_key_id" {

--- a/kubernetes/aws/eks/variables.tf
+++ b/kubernetes/aws/eks/variables.tf
@@ -293,6 +293,73 @@ variable "efs_csi_version" {
   type        = string
 }
 
+# EBS
+
+variable "ebs_csi_image" {
+  description = "EBS CSI image name"
+  type        = string
+}
+variable "ebs_csi_tag" {
+  description = "EBS CSI image tag"
+  type        = string
+}
+variable "ebs_csi_liveness_probe_image" {
+  description = "EBS CSI liveness probe image name"
+  type        = string
+}
+variable "ebs_csi_liveness_probe_tag" {
+  description = "EBS CSI liveness probe image tag"
+  type        = string
+}
+variable "ebs_csi_node_driver_registrar_image" {
+  description = "EBS CSI node driver registrar image name"
+  type        = string
+}
+variable "ebs_csi_node_driver_registrar_tag" {
+  description = "EBS CSI node driver registrar image tag"
+  type        = string
+}
+variable "ebs_csi_external_provisioner_image" {
+  description = "EBS CSI external provisioner image name"
+  type        = string
+}
+variable "ebs_csi_external_provisioner_tag" {
+  description = "EBS CSI external provisioner image tag"
+  type        = string
+}
+variable "ebs_csi_name" {
+  description = "EBS CSI name"
+  type        = string
+  default     = null
+}
+variable "ebs_csi_namespace" {
+  description = "EBS CSI namespace"
+  type        = string
+  default     = null
+}
+variable "ebs_csi_image_pull_secrets" {
+  description = "Image pull secret used to pull EFS CSI images"
+  type        = string
+  default     = null
+}
+variable "ebs_csi_repository" {
+  description = "EBS CSI helm repository"
+  type        = string
+}
+variable "ebs_csi_version" {
+  description = "EBS CSI helm version"
+  type        = string
+}
+variable "ebs_csi_controller_resources" {
+  description = "Resources to allocate for EBS CSI driver controller"
+  type = object({
+    limits   = optional(map(string))
+    requests = optional(map(string))
+  })
+  default = {}
+}
+
+
 # Encryption keys
 variable "cluster_log_kms_key_id" {
   description = "KMS id to encrypt/decrypt the cluster's logs"

--- a/storage/onpremise/mongodb-sharded/persistence.tf
+++ b/storage/onpremise/mongodb-sharded/persistence.tf
@@ -9,7 +9,7 @@ resource "kubernetes_storage_class" "shards" {
       service = "persistent-volume"
     }
   }
-  mount_options       = ["tls"]
+  mount_options       = var.persistence.shards.storage_provisioner == "ebs.csi.aws.com" ? null : ["tls"]
   storage_provisioner = var.persistence.shards.storage_provisioner
   reclaim_policy      = var.persistence.shards.reclaim_policy
   volume_binding_mode = var.persistence.shards.volume_binding_mode
@@ -27,7 +27,7 @@ resource "kubernetes_storage_class" "configsvr" {
       service = "persistent-volume"
     }
   }
-  mount_options       = ["tls"]
+  mount_options       = var.persistence.configsvr.storage_provisioner == "ebs.csi.aws.com" ? null : ["tls"]
   storage_provisioner = var.persistence.configsvr.storage_provisioner
   reclaim_policy      = var.persistence.configsvr.reclaim_policy
   volume_binding_mode = var.persistence.configsvr.volume_binding_mode

--- a/storage/onpremise/mongodb/persistent-volume.tf
+++ b/storage/onpremise/mongodb/persistent-volume.tf
@@ -9,7 +9,7 @@ resource "kubernetes_storage_class" "mongodb" {
       service = "persistent-volume"
     }
   }
-  mount_options       = ["tls"]
+  mount_options       = var.persistent_volume.storage_provisioner == "ebs.csi.aws.com" ? null : ["tls"]
   storage_provisioner = var.persistent_volume.storage_provisioner
   reclaim_policy      = var.persistent_volume.reclaim_policy
   volume_binding_mode = var.persistent_volume.volume_binding_mode


### PR DESCRIPTION
# Motivation

This PR introduces the capacity to provision EBS persistent volumes for MongoDB pods on EKS. Our sharded MongoDB deployment is unstable without persistence while we only supported persistence through EFS, which was not performance-friendly.

# Description

This PR enables to deploy the standard EBS CSI on EKS while disabling TLS mount option for the EBS volumes to be provisioned, as it seems to not be supported by the provisioner yet.

# Testing

Successfully deployed the driver on AWS and was able to provision EBS volumes for MongoDB and MongoDB sharded pods.

# Impact

Might have a significant impact on performance for our sharded MongoDB deployment.
 
# Additional Information

On the mid-term, TLS mounting of EBS volumes would be to implement.

# Checklist

- [X] My code adheres to the coding and style guidelines of the project.
- [X] I have performed a self-review of my code.
- [X] I have commented my code, particularly in hard-to-understand areas.
- [X] I have made corresponding changes to the documentation.
- [X] I have thoroughly tested my modifications and added tests when necessary.
- [X] Tests pass locally and in the CI.
- [X] I have assessed the performance impact of my modifications.