### PR TITLE
fix: SQS policy resource prefix

### DIFF
--- a/storage/aws/sqs/main.tf
+++ b/storage/aws/sqs/main.tf
@@ -1,9 +1,11 @@
-locals {
-  prefix = var.prefix
-  region = var.region
-  tags   = merge(var.tags, { module = "amazon-sqs" })
-}
+data "aws_caller_identity" "current" {}
 
+locals {
+  prefix     = var.prefix
+  region     = var.region
+  account_id = data.aws_caller_identity.current.account_id
+  tags       = merge(var.tags, { module = "amazon-sqs" })
+}
 
 data "aws_iam_policy_document" "sqs" {
   statement {
@@ -21,7 +23,7 @@ data "aws_iam_policy_document" "sqs" {
       "sqs:ChangeMessageVisibility"
     ]
     effect    = "Allow"
-    resources = ["arn:aws:sqs:::${local.prefix}*"]
+    resources = ["arn:aws:sqs:${local.region}:${local.account_id}:${local.prefix}*"]
   }
 }
 

--- a/storage/aws/sqs/variables.tf
+++ b/storage/aws/sqs/variables.tf
@@ -15,6 +15,6 @@ variable "tags" {
 }
 
 variable "service_account_role_name" {
-  description = "Name of the IAM role to give the SQS permissions to"
+  description = "Name of the IAM role associated to the AWS service account. This role will be given SQS permissions."
   type        = string
 }


### PR DESCRIPTION
# Motivation

The SQS PR was merged prematurely, it was missing a change to the policy document that pointed to the wrong resource.

# Description

Fixed the resource that the SQS policies applied to. This bug prevented deployment with SQS because it would point towards a resource that doesn't exist.

# Testing

Previous tests pass as this PR doesn't affect them. These changes have already been taken into consideration in the SQS benchmarks/testing.

# Impact

Not applicable.

# Additional Information

Not applicable. 

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.