### PR TITLE
feat: Autogenerated config file for ArmoniK CLI

### DIFF
--- a/armonik/README.md
+++ b/armonik/README.md
@@ -68,6 +68,7 @@
 | [kubernetes_service.control_plane](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
 | [kubernetes_service.ingress](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service) | resource |
 | [kubernetes_service_account.pod_deletion_cost](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/service_account) | resource |
+| [local_file.armonik_config](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_file.ingress_conf_file](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/file) | resource |
 | [local_sensitive_file.ingress_ca](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [local_sensitive_file.ingress_client_ca](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
@@ -123,5 +124,6 @@
 
 | Name | Description |
 |------|-------------|
+| <a name="output_armonik_config_file"></a> [armonik\_config\_file](#output\_armonik\_config\_file) | Path to the generated ArmoniK configuration file |
 | <a name="output_endpoint_urls"></a> [endpoint\_urls](#output\_endpoint\_urls) | List of URL endpoints for: control-plane, Seq, Grafana and Admin GUI |
 <!-- END_TF_DOCS -->

--- a/armonik/outputs.tf
+++ b/armonik/outputs.tf
@@ -1,3 +1,27 @@
+locals {
+
+  armonik_cli_config = {
+    endpoint              = coalesce(local.ingress_grpc_url, local.control_plane_url)
+    certificate_authority = try(abspath(local_sensitive_file.ingress_ca[0].filename), null)
+    client_certificate    = try(abspath(local_sensitive_file.ingress_client_crt["Submitter"].filename), null)
+    client_key            = try(abspath(local_sensitive_file.ingress_client_key["Submitter"].filename), null)
+  }
+
+}
+
+# Create the configuration file
+resource "local_file" "armonik_config" {
+  content         = "# ArmoniK Connection Configuration\n---\n${yamlencode({ for k, v in local.armonik_cli_config : k => v if v != null })}"
+  filename        = "${path.root}/generated/armonik-cli.yaml"
+  file_permission = "0644"
+}
+
+output "armonik_config_file" {
+  description = "Path to the generated ArmoniK configuration file"
+  value       = abspath(local_file.armonik_config.filename)
+}
+
+
 output "endpoint_urls" {
   description = "List of URL endpoints for: control-plane, Seq, Grafana and Admin GUI"
   value = var.ingress != null ? {


### PR DESCRIPTION
# Motivation

Needed a way to easily point the ArmoniK CLI to your current deployment.

# Description

Autogenerate an additional ArmoniK CLI config as well as the necessary certificates for connection via TLS. 

# Testing

Tested with both TLS enabled and disabled on a local host deployment. 

# Impact

Not applicable.

# Additional Information

Not applicable.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.