### PR TITLE
fix: remove SSL parameter in outputs file for ActiveMQ and RabbitMQ

### DIFF
--- a/storage/aws/mq/outputs.tf
+++ b/storage/aws/mq/outputs.tf
@@ -56,10 +56,8 @@ output "env" {
     "Components__QueueAdaptorSettings__AdapterAbsolutePath" = var.adapter_absolute_path
     "Amqp__Host"                                            = aws_mq_broker.mq.engine_type == "ActiveMQ" ? trim(split(":", aws_mq_broker.mq.instances[0].endpoints[1])[1], "//") : trim(split(":", aws_mq_broker.mq.instances[0].endpoints[0])[1], "//")
     "Amqp__Port"                                            = aws_mq_broker.mq.engine_type == "ActiveMQ" ? tonumber(split(":", aws_mq_broker.mq.instances[0].endpoints[1])[2]) : tonumber(split(":", aws_mq_broker.mq.instances[0].endpoints[0])[2])
-    "Amqp__Scheme"                                          = var.scheme
-    "Amqp__Ssl"                                             = true
+    "Amqp__Scheme"                                          = var.scheme # Indicates also whether we use TLS or not
   })
-
 }
 
 output "env_secret" {

--- a/storage/onpremise/activemq/outputs.tf
+++ b/storage/onpremise/activemq/outputs.tf
@@ -67,11 +67,9 @@ output "env" {
     "Components__QueueAdaptorSettings__AdapterAbsolutePath" = local.adapter_absolute_path
     "Amqp__Host"                                            = local.activemq_dns
     "Amqp__Port"                                            = local.activemq_endpoints.port
-    "Amqp__Scheme"                                          = var.scheme
+    "Amqp__Scheme"                                          = var.scheme # Indicates also whether we use TLS or not
     "Amqp__CaPath"                                          = "${var.path}/ca.pem"
-    "Amqp__Ssl"                                             = "true"
   })
-
 }
 
 output "env_secret" {

--- a/storage/onpremise/rabbitmq/outputs.tf
+++ b/storage/onpremise/rabbitmq/outputs.tf
@@ -67,11 +67,9 @@ output "env" {
     "Components__QueueAdaptorSettings__AdapterAbsolutePath" = local.adapter_absolute_path
     "Amqp__Host"                                            = local.rabbitmq_dns
     "Amqp__Port"                                            = local.rabbitmq_endpoints.port
-    "Amqp__Scheme"                                          = var.scheme
+    "Amqp__Scheme"                                          = var.scheme # Indicates also whether we use TLS or not
     "Amqp__CaPath"                                          = "${var.path}/ca.pem"
-    "Amqp__Ssl"                                             = "true"
   })
-
 }
 
 output "env_secret" {


### PR DESCRIPTION
# Motivation

Simplify TLS configuration by using a single parameter (the scheme) to indicate whether TLS should be applied.

# Description

Use only **Amqp__Scheme** parameter to control TLS for AMQP connections, reducing configuration complexity

# Testing

Tests were ran on localhost for RabbitMQ and ActiveMQ. 
Another was ran for AmazonMQ

# Impact

Simplifies TLS configuration, reducing potential errors and improving code clarity. No significant performance impact.

# Additional Information

Note that this change will not be functional with older versions of Core, as the old **Amqp__Ssl** parameter is checked in the old Core version. Ensure that you are using the latest version of Core to benefit from this simplified configuration.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.