### PR TITLE
ci: Split renovate PRs into groups

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 39.205.1
     hooks:
       - id: renovate-config-validator
-        args: [--strict]
+        # args: [--strict]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.80.0
     hooks:
@@ -35,7 +35,7 @@ repos:
           - '--args=--only=terraform_module_version'
       #- id: terraform_tfsec
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v5.0.0
     hooks:
       - id: check-executables-have-shebangs
       - id: check-merge-conflict

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,4 +1,9 @@
 repos:
+  - repo: https://github.com/renovatebot/pre-commit-hooks
+    rev: 39.205.1
+    hooks:
+      - id: renovate-config-validator
+        args: [--strict]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.80.0
     hooks:

--- a/renovate.json
+++ b/renovate.json
@@ -3,9 +3,60 @@
   "extends": [
     "config:base",
     "group:allNonMajor",
-    ":semanticCommits"
+    ":semanticCommitTypeAll(chore)",
+    "helpers:pinGitHubActionDigests"
   ],
+  "configMigration": true,
+  "rangeStrategy": "bump",
   "packageRules": [
+    {
+      "groupName": "docker images",
+      "groupSlug": "docker",
+      "matchDatasources": [
+        "docker"
+      ]
+    },
+    {
+      "groupName": "terraform modules",
+      "groupSlug": "terraform-module",
+      "matchDatasources": [
+        "terraform-module"
+      ]
+    },
+    {
+      "groupName": "terraform provider",
+      "groupSlug": "terraform-provider",
+      "matchFileNames": [
+        "!**/examples/**"
+      ],
+      "matchDatasources": [
+        "terraform-provider"
+      ]
+    },
+    {
+      "groupName": "terraform provider examples",
+      "groupSlug": "terraform-provider examples",
+      "matchFileNames": [
+        "**/examples/**"
+      ],
+      "matchDatasources": [
+        "terraform-provider"
+      ]
+    },
+    {
+      "groupName": "helm charts",
+      "groupSlug": "helm-charts",
+      "matchDatasources": [
+        "helm"
+      ]
+    },
+    {
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "matchDatasources": [
+        "github-tags"
+      ]
+    },
     {
       "matchPackagePrefixes": [
         "ArmoniK"


### PR DESCRIPTION
# Motivation

Renovate creates a single PR for all kind of dependency update.

# Description

Splits the PR into multiple groups:
- Docker images
- Terraform modules
- Terraform providers
- Terraform providers for examples
- Helm charts
- Github actions
- Other packages

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.