### PR TITLE
ci: Proper order for Renovate packageRules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,7 +3,7 @@ repos:
     rev: 39.205.1
     hooks:
       - id: renovate-config-validator
-        # args: [--strict]
+        args: [--strict]
   - repo: https://github.com/antonbabenko/pre-commit-terraform
     rev: v1.80.0
     hooks:

--- a/renovate.json
+++ b/renovate.json
@@ -8,12 +8,33 @@
   ],
   "configMigration": true,
   "rangeStrategy": "bump",
+  "ignorePaths": [],
   "packageRules": [
+    {
+      "groupName": "other dependencies",
+      "matchPackageNames": [
+        "*"
+      ]
+    },
+    {
+      "groupName": "github actions",
+      "groupSlug": "github-actions",
+      "matchDatasources": [
+        "github-tags"
+      ]
+    },
     {
       "groupName": "docker images",
       "groupSlug": "docker",
       "matchDatasources": [
         "docker"
+      ]
+    },
+    {
+      "groupName": "helm charts",
+      "groupSlug": "helm-charts",
+      "matchDatasources": [
+        "helm"
       ]
     },
     {
@@ -26,9 +47,6 @@
     {
       "groupName": "terraform provider",
       "groupSlug": "terraform-provider",
-      "matchFileNames": [
-        "!**/examples/**"
-      ],
       "matchDatasources": [
         "terraform-provider"
       ]
@@ -44,30 +62,9 @@
       ]
     },
     {
-      "groupName": "helm charts",
-      "groupSlug": "helm-charts",
-      "matchDatasources": [
-        "helm"
-      ]
-    },
-    {
-      "groupName": "github actions",
-      "groupSlug": "github-actions",
-      "matchDatasources": [
-        "github-tags"
-      ]
-    },
-    {
       "groupName": "release packages Armonik",
       "matchPackageNames": [
         "ArmoniK{/,}**"
-      ]
-    },
-    {
-      "groupName": "other dependencies",
-      "matchPackageNames": [
-        "*",
-        "!ArmoniK{/,}**"
       ]
     }
   ]


### PR DESCRIPTION
# Motivation

Renovate packageRules are ordered from lower precedence to higher precedence, but we ordered them from most specific to least specific. Therefore, all updates ended-up into the least specific (but highest precedence) rule.

# Description

Move the least specific rules first to match the precedence of Renovate.

# Testing

Cannot be tested before landing on main.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.