### PR TITLE
fix: compute plane configuration

### DIFF
--- a/armonik/compute-plane-configmap.tf
+++ b/armonik/compute-plane-configmap.tf
@@ -18,7 +18,7 @@ module "polling_all_aggregation" {
       Amqp__LinkCredit               = "2"
       Pollster__GraceDelay           = "00:00:15"
     }
-  }, module.core_aggregation, module.compute_aggregation, var.configurations.polling])
+  }, module.core_aggregation, module.compute_all_aggregation, var.configurations.polling])
   materialize_configmap = {
     name      = "polling-configmap"
     namespace = var.namespace
@@ -34,7 +34,7 @@ module "worker_all_aggregation" {
     }
     }, {
     env = local.file_storage_endpoints
-  }, module.compute_aggregation, var.configurations.worker])
+  }, module.compute_all_aggregation, var.configurations.worker])
   materialize_configmap = {
     name      = "worker-configmap"
     namespace = var.namespace


### PR DESCRIPTION
# Motivation

There was an issue where log configuration and compute configuration were not propagated to compute pods.

# Description

Target the compute-all aggregation  instead of compute.

# Testing

Local deployment shows that log configuration is now properly propagated to compute plane.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.