### PR TITLE
fix: mTLS Common name filled incorrectly set

### DIFF
--- a/armonik/authentication-in-database.tf
+++ b/armonik/authentication-in-database.tf
@@ -245,7 +245,7 @@ var aggregation_certs = [
   }, {
     '$project': {
       '_id': 0,
-      'CN': 1,
+      'Cn': 1,
       'Fingerprint': 1,
       'UserId': {
         '$arrayElemAt': [

--- a/armonik/authentication-roles-default.tf
+++ b/armonik/authentication-roles-default.tf
@@ -21,11 +21,36 @@ locals {
         "Sessions:CancelSession",
         "Sessions:GetSession",
         "Sessions:ListSessions",
+        "Sessions:CreateSession",
+        "Sessions:PauseSession",
+        "Sessions:CloseSession",
+        "Sessions:PurgeSession",
+        "Sessions:DeleteSession",
+        "Sessions:ResumeSession",
+        "Sessions:StopSubmission",
         "Tasks:GetTask",
         "Tasks:ListTasks",
         "Tasks:GetResultIds",
+        "Tasks:CancelTasks",
+        "Tasks:CountTasksByStatus",
+        "Tasks:ListTasksDetailed",
+        "Tasks:SubmitTasks",
         "Results:GetOwnerTaskId",
-        "General:Impersonate"
+        "Results:ListResults",
+        "Results:CreateResultsMetaData",
+        "Results:CreateResults",
+        "Results:DeleteResultsData",
+        "Results:DownloadResultData",
+        "Results:GetServiceConfiguration",
+        "Results:UploadResultData",
+        "Results:GetResult",
+        "Results:ImportResultsData",
+        "Applications:ListApplications",
+        "Events:GetEvents",
+        "General:Impersonate",
+        "Partitions:GetPartition",
+        "Partitions:ListPartitions",
+        "Versions:ListVersions"
       ]
       "Monitoring" = [
         "Submitter:GetServiceConfiguration",
@@ -39,7 +64,17 @@ locals {
         "Tasks:GetTask",
         "Tasks:ListTasks",
         "Tasks:GetResultIds",
-        "Results:GetOwnerTaskId"
+        "Tasks:CountTasksByStatus",
+        "Tasks:ListTasksDetailed",
+        "Results:GetOwnerTaskId",
+        "Results:ListResults",
+        "Results:GetServiceConfiguration",
+        "Results:GetResult",
+        "Applications:ListApplications",
+        "Events:GetEvents",
+        "Partitions:GetPartition",
+        "Partitions:ListPartitions",
+        "Versions:ListVersions"
       ]
     })
   }


### PR DESCRIPTION
fix: mTLS Common name filled incorrectly set
fix: Missing default permissions

# Motivation

Following a change 2 years ago, the Common name field in MongoDB was set incorrectly (CN instead of Cn)

# Description

[Provide a detailled explanation of the modifications you have made. Link any related issues.]

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.