### PR TITLE
fix: Seq noauthentification behavior

### DIFF
--- a/monitoring/onpremise/seq/main.tf
+++ b/monitoring/onpremise/seq/main.tf
@@ -69,6 +69,10 @@ resource "kubernetes_deployment" "seq" {
               value = "FMB0CwtRt8CwkiSDebSmdJszUzK9B52DV19CKdpFyGtrGRkBrQ=="
             }
           }
+          env {
+            name  = "SEQ_FIRSTRUN_NOAUTHENTICATION"
+            value = !var.authentication
+          }
           port {
             name           = "ingestion"
             container_port = 5341


### PR DESCRIPTION
# Description

Added an environment variable to disable Seq’s forced admin authentication on first run.

# Impact

Allows Seq to start without requiring an admin password, useful for dev/test environments.

# Checklist

* [x] Code follows project guidelines
* [] Local testing done (Seq starts without errors)
* [x] Documentation updated if needed