### PR TITLE
fix: Restrict Helm and AWS versions

### DIFF
--- a/armonik/README.md
+++ b/armonik/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.21.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.1.0 |
 | <a name="requirement_pkcs12"></a> [pkcs12](#requirement\_pkcs12) | >= 0.0.7 |
@@ -15,7 +15,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.21.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.1.0 |
 | <a name="provider_pkcs12"></a> [pkcs12](#provider\_pkcs12) | >= 0.0.7 |

--- a/armonik/versions.tf
+++ b/armonik/versions.tf
@@ -7,7 +7,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     pkcs12 = {
       source  = "chilicat/pkcs12"

--- a/kubernetes/aws/addons/efs-csi/README.md
+++ b/kubernetes/aws/addons/efs-csi/README.md
@@ -6,7 +6,7 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61, < 6.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.22.0 |
 
@@ -14,7 +14,7 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61, < 6.0.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.22.0 |
 

--- a/kubernetes/aws/addons/efs-csi/README.md
+++ b/kubernetes/aws/addons/efs-csi/README.md
@@ -7,7 +7,7 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.22.0 |
 
 ## Providers
@@ -15,7 +15,7 @@ Amazon Elastic File System (Amazon EFS) provides serverless, fully elastic file 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.22.0 |
 
 ## Modules

--- a/kubernetes/aws/addons/efs-csi/examples/complete/README.md
+++ b/kubernetes/aws/addons/efs-csi/examples/complete/README.md
@@ -22,7 +22,7 @@ terraform destroy
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.22.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 

--- a/kubernetes/aws/addons/efs-csi/examples/complete/versions.tf
+++ b/kubernetes/aws/addons/efs-csi/examples/complete/versions.tf
@@ -53,7 +53,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.10.1"
+      version = "~> 2.10.1, < 3.0.0"
     }
   }
 }

--- a/kubernetes/aws/addons/efs-csi/versions.tf
+++ b/kubernetes/aws/addons/efs-csi/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.61, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/kubernetes/aws/addons/efs-csi/versions.tf
+++ b/kubernetes/aws/addons/efs-csi/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
   }
 }

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61, < 6.0.0 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
@@ -14,7 +14,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61, < 6.0.0 |
 | <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.13.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |

--- a/kubernetes/aws/eks/README.md
+++ b/kubernetes/aws/eks/README.md
@@ -5,7 +5,7 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.13.0 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
@@ -15,7 +15,7 @@
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.61 |
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.13.0 |
 | <a name="provider_null"></a> [null](#provider\_null) | >= 3.2.1 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |

--- a/kubernetes/aws/eks/examples/complete/README.md
+++ b/kubernetes/aws/eks/examples/complete/README.md
@@ -22,7 +22,7 @@ terraform destroy
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.21.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 

--- a/kubernetes/aws/eks/examples/complete/versions.tf
+++ b/kubernetes/aws/eks/examples/complete/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.10.1"
+      version = "~> 2.10.1, < 3.0.0"
     }
   }
 }

--- a/kubernetes/aws/eks/examples/simple/README.md
+++ b/kubernetes/aws/eks/examples/simple/README.md
@@ -22,7 +22,7 @@ terraform destroy
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.61 |
 | <a name="requirement_external"></a> [external](#requirement\_external) | ~> 2.3.1 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | ~> 2.21.1 |
 | <a name="requirement_null"></a> [null](#requirement\_null) | >= 3.2.1 |
 

--- a/kubernetes/aws/eks/examples/simple/versions.tf
+++ b/kubernetes/aws/eks/examples/simple/versions.tf
@@ -25,7 +25,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = "~> 2.10.1"
+      version = "~> 2.10.1, < 3.0.0"
     }
   }
 }

--- a/kubernetes/aws/eks/versions.tf
+++ b/kubernetes/aws/eks/versions.tf
@@ -11,7 +11,7 @@ terraform {
     }
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/kubernetes/aws/eks/versions.tf
+++ b/kubernetes/aws/eks/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.61"
+      version = ">= 5.61, < 6.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/monitoring/onpremise/keda/README.md
+++ b/monitoring/onpremise/keda/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 
 ## Modules
 

--- a/monitoring/onpremise/keda/versions.tf
+++ b/monitoring/onpremise/keda/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
   }
 }

--- a/monitoring/onpremise/metrics-server/README.md
+++ b/monitoring/onpremise/metrics-server/README.md
@@ -4,13 +4,13 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 
 ## Modules
 

--- a/monitoring/onpremise/metrics-server/versions.tf
+++ b/monitoring/onpremise/metrics-server/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
   }
 }

--- a/storage/onpremise/mongodb-sharded/examples/complete/versions.tf
+++ b/storage/onpremise/mongodb-sharded/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/storage/onpremise/mongodb-sharded/examples/simple/versions.tf
+++ b/storage/onpremise/mongodb-sharded/examples/simple/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/storage/onpremise/mongodb-sharded/versions.tf
+++ b/storage/onpremise/mongodb-sharded/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/storage/onpremise/mongodb/README.md
+++ b/storage/onpremise/mongodb/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.21.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.5.1 |
@@ -13,7 +13,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.21.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.4.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.5.1 |

--- a/storage/onpremise/mongodb/examples/complete/README.md
+++ b/storage/onpremise/mongodb/examples/complete/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.21.1 |
 
 ## Providers

--- a/storage/onpremise/mongodb/examples/complete/versions.tf
+++ b/storage/onpremise/mongodb/examples/complete/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/storage/onpremise/mongodb/examples/simple/README.md
+++ b/storage/onpremise/mongodb/examples/simple/README.md
@@ -21,7 +21,7 @@ terraform destroy
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.10.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.21.1 |
 
 ## Providers

--- a/storage/onpremise/mongodb/examples/simple/versions.tf
+++ b/storage/onpremise/mongodb/examples/simple/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"

--- a/storage/onpremise/mongodb/versions.tf
+++ b/storage/onpremise/mongodb/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.10.1"
+      version = ">= 2.10.1, < 3.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/storage/onpremise/rabbitmq/README.md
+++ b/storage/onpremise/rabbitmq/README.md
@@ -4,7 +4,7 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.12.1 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 2.12.1, < 3.0.0 |
 | <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.7.1 |
 | <a name="requirement_local"></a> [local](#requirement\_local) | >= 2.4.0 |
 | <a name="requirement_pkcs12"></a> [pkcs12](#requirement\_pkcs12) | >= 0.0.7 |
@@ -14,7 +14,7 @@
 
 | Name | Version |
 |------|---------|
-| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.12.1 |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | >= 2.12.1, < 3.0.0 |
 | <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.7.1 |
 | <a name="provider_local"></a> [local](#provider\_local) | >= 2.4.0 |
 | <a name="provider_pkcs12"></a> [pkcs12](#provider\_pkcs12) | >= 0.0.7 |

--- a/storage/onpremise/rabbitmq/versions.tf
+++ b/storage/onpremise/rabbitmq/versions.tf
@@ -3,7 +3,7 @@ terraform {
   required_providers {
     helm = {
       source  = "hashicorp/helm"
-      version = ">= 2.12.1"
+      version = ">= 2.12.1, < 3.0.0"
     }
     kubernetes = {
       source  = "hashicorp/kubernetes"


### PR DESCRIPTION
# Motivation

Helm provider has been updated to plugin framework, and removed blocks from provider configuration.
It appears that this new version is not yet stable enough: https://github.com/hashicorp/terraform-provider-helm/issues/1637

AWS provider uptated to 6.0 which has a few incompatiblities, especially regarding elastic accelerators.


# Description

Restrict the helm provider version to `< 3.0.0` and aws provider version to `< 6.0.0`.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.