### PR TITLE
refactor: Add Pollster__PartitionId

### DIFF
--- a/armonik/locals.tf
+++ b/armonik/locals.tf
@@ -1,6 +1,6 @@
 locals {
   # Supported message queues by ArmoniK
-  supported_queues = toset(["Amqp__PartitionId", "PubSub__PartitionId", "SQS__PartitionId"])
+  supported_queues = toset(["Pollster__PartitionId", "Amqp__PartitionId", "PubSub__PartitionId", "SQS__PartitionId"])
 
   # list of partitions
   partition_names   = keys(try(var.compute_plane, {}))


### PR DESCRIPTION
# Motivation

Newer version of ArmoniK.Core requires the environment variable Pollster__PartitionId.

# Description

Add Pollster__PartitionId to the list of supported queues.

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.