### PR TITLE
refactor: MongoDB exporter refactor 

### DIFF
--- a/armonik/authentication-in-database.tf
+++ b/armonik/authentication-in-database.tf
@@ -280,8 +280,10 @@ db.Temp_AuthData.drop();
   EOF
 
   authentication_script = <<EOF
-#!/bin/bash
-mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls --username $MongoDB__User --password $MongoDB__Password mongodb://$MongoDB__Host:$MongoDB__Port/database /mongodb/script/initauth.js
+if [ -z "$MongoDB__ConnectionString" ]; then
+  MongoDB__ConnectionString="mongodb+srv://$MongoDB__User:$MongoDB__Password@$MongoDB__Host:$MongoDB__Port/$MongoDB__DatabaseName"
+fi
+mongosh --tlsCAFile $MongoDB__CAFile --tlsAllowInvalidCertificates --tlsAllowInvalidHostnames --tls "$MONGODB_ConnectionString" /mongodb/script/initauth.js
 EOF
 }
 

--- a/monitoring/onpremise/exporters/mongodb-exporter/README.md
+++ b/monitoring/onpremise/exporters/mongodb-exporter/README.md
@@ -14,7 +14,9 @@
 
 ## Modules
 
-No modules.
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_mongodb_aggregator"></a> [mongodb\_aggregator](#module\_mongodb\_aggregator) | ../../../../utils/aggregator | n/a |
 
 ## Resources
 
@@ -27,10 +29,11 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_certif_mount"></a> [certif\_mount](#input\_certif\_mount) | MongoDB certificate mount secret | <pre>map(object({<br/>    secret = string<br/>    path   = string<br/>    mode   = string<br/>  }))</pre> | n/a | yes |
-| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image for partition metrics exporter | <pre>object({<br/>    image              = string<br/>    tag                = string<br/>    image_pull_secrets = string<br/>  })</pre> | n/a | yes |
-| <a name="input_mongo_url"></a> [mongo\_url](#input\_mongo\_url) | Full MongoDB URI with credentials and tls options included | `string` | n/a | yes |
-| <a name="input_namespace"></a> [namespace](#input\_namespace) | Namespace of ArmoniK resources | `string` | n/a | yes |
+| <a name="input_disable_diagnostic_data"></a> [disable\_diagnostic\_data](#input\_disable\_diagnostic\_data) | When working with a sharded on-premise MongoDB deployment, this flag works around the exporter crashing (but exports less metrics) | `bool` | `false` | no |
+| <a name="input_docker_image"></a> [docker\_image](#input\_docker\_image) | Docker image for MongoDB metrics exporter | <pre>object({<br/>    image              = string<br/>    tag                = string<br/>    image_pull_secrets = string<br/>  })</pre> | n/a | yes |
+| <a name="input_force_split_cluster"></a> [force\_split\_cluster](#input\_force\_split\_cluster) | Used when working with mongodb+srv URIs (this is typically the case with Atlas-managed MongoDB), it adds the '--split-cluster' flag to the exporter flags. You can force this to be on. | `bool` | `false` | no |
+| <a name="input_mongodb_modules"></a> [mongodb\_modules](#input\_mongodb\_modules) | MongoDB modules to use when building the exporter (assumes only one is actually active) | `any` | n/a | yes |
+| <a name="input_namespace"></a> [namespace](#input\_namespace) | Kubernetes namespace to use for this resource | `string` | n/a | yes |
 
 ## Outputs
 

--- a/monitoring/onpremise/exporters/mongodb-exporter/main.tf
+++ b/monitoring/onpremise/exporters/mongodb-exporter/main.tf
@@ -1,3 +1,37 @@
+module "mongodb_aggregator" {
+  source = "../../../../utils/aggregator"
+
+  conf_list = flatten([var.mongodb_modules])
+}
+
+locals {
+  # Base arguments
+  base_args = [
+    "--log.level=error",
+    "--collector.replicasetstatus",
+    "--collector.dbstats",
+    "--collector.dbstatsfreestorage",
+    "--collector.topmetrics",
+    "--collector.currentopmetrics",
+    "--collector.indexstats",
+    "--collector.collstats",
+    "--mongodb.uri=$(MongoDB__MonitoringConnectionString)",
+    "--discovering-mode"
+  ]
+
+  # Conditionally add diagnostic data collector (We do this to work around a crash for sharded mongodb)
+  diagnostic_args = var.disable_diagnostic_data != true ? ["--collector.diagnosticdata"] : []
+
+  # TODO (This requires an init_container, might not be worth it..): if the URI starts with mongodb+srv then split the cluster otherwise check if force_split_cluster is true
+  split_cluster_args = var.force_split_cluster == true ? ["--split-cluster"] : []
+
+  args = concat(
+    local.base_args,
+    local.diagnostic_args,
+    local.split_cluster_args
+  )
+}
+
 resource "kubernetes_deployment" "mongodb_exporter" {
   metadata {
     name      = "mongodb-metrics-exporter"
@@ -34,34 +68,50 @@ resource "kubernetes_deployment" "mongodb_exporter" {
           name  = "mongodb-metrics-exporter"
           image = var.docker_image.tag != "" ? "${var.docker_image.image}:${var.docker_image.tag}" : var.docker_image.image
 
-          env {
-            name  = "MONGODB_URI"
-            value = var.mongo_url
+          # Environment variables from regular env output
+          dynamic "env" {
+            for_each = module.mongodb_aggregator.env
+            content {
+              name  = env.key
+              value = env.value
+            }
           }
 
+          # Environment variables from secrets
+          dynamic "env" {
+            for_each = module.mongodb_aggregator.env_from_secret
+            content {
+              name = env.key
+              value_from {
+                secret_key_ref {
+                  name = env.value.secret
+                  key  = env.value.field
+                }
+              }
+            }
+          }
           dynamic "volume_mount" {
-            for_each = var.certif_mount
+            for_each = module.mongodb_aggregator.mount_secret
             content {
               mount_path = volume_mount.value.path
-              name       = volume_mount.value.secret
+              name       = volume_mount.key
               read_only  = true
             }
           }
 
-          args = ["--log.level=error", "--collector.diagnosticdata", "--collector.replicasetstatus", "--collector.dbstats", "--collector.dbstatsfreestorage", "--collector.topmetrics", "--collector.currentopmetrics", "--collector.indexstats", "--collector.collstats", "--discovering-mode", "--mongodb.uri=$(MONGODB_URI)"]
+          args = local.args
         }
 
         dynamic "volume" {
-          for_each = var.certif_mount
+          for_each = module.mongodb_aggregator.mount_secret
           content {
-            name = volume.value.secret
+            name = volume.key
             secret {
               secret_name  = volume.value.secret
               default_mode = volume.value.mode
             }
           }
         }
-
       }
     }
   }

--- a/monitoring/onpremise/exporters/mongodb-exporter/variables.tf
+++ b/monitoring/onpremise/exporters/mongodb-exporter/variables.tf
@@ -1,12 +1,12 @@
 # Global variables
 variable "namespace" {
-  description = "Namespace of ArmoniK resources"
+  description = "Kubernetes namespace to use for this resource"
   type        = string
 }
 
 # Docker image
 variable "docker_image" {
-  description = "Docker image for partition metrics exporter"
+  description = "Docker image for MongoDB metrics exporter"
   type = object({
     image              = string
     tag                = string
@@ -14,16 +14,19 @@ variable "docker_image" {
   })
 }
 
-variable "certif_mount" {
-  description = "MongoDB certificate mount secret"
-  type = map(object({
-    secret = string
-    path   = string
-    mode   = string
-  }))
+variable "force_split_cluster" {
+  description = "Used when working with mongodb+srv URIs (this is typically the case with Atlas-managed MongoDB), it adds the '--split-cluster' flag to the exporter flags. You can force this to be on."
+  type        = bool
+  default     = false
 }
 
-variable "mongo_url" {
-  description = "Full MongoDB URI with credentials and tls options included"
-  type        = string
+variable "disable_diagnostic_data" {
+  description = "When working with a sharded on-premise MongoDB deployment, this flag works around the exporter crashing (but exports less metrics)"
+  type        = bool
+  default     = false
+}
+
+variable "mongodb_modules" {
+  description = "MongoDB modules to use when building the exporter (assumes only one is actually active)"
+  type        = any
 }

--- a/storage/atlas/README.md
+++ b/storage/atlas/README.md
@@ -57,11 +57,15 @@ No modules.
 | [kubernetes_secret.mongodb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.mongodb_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.mongodbatlas_connection_string](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.mongodbatlas_monitoring_connection_string](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [mongodbatlas_database_user.admin](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user) | resource |
+| [mongodbatlas_database_user.monitoring](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/database_user) | resource |
 | [mongodbatlas_privatelink_endpoint.pe](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint) | resource |
 | [mongodbatlas_privatelink_endpoint_service.pe_service](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/resources/privatelink_endpoint_service) | resource |
 | [random_password.mongodb_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.mongodb_monitoring_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.mongodb_admin_user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [random_string.mongodb_monitoring_user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [mongodbatlas_advanced_cluster.akaws](https://registry.terraform.io/providers/mongodb/mongodbatlas/latest/docs/data-sources/advanced_cluster) | data source |
 
 ## Inputs

--- a/storage/atlas/credentials.tf
+++ b/storage/atlas/credentials.tf
@@ -8,3 +8,14 @@ resource "random_password" "mongodb_admin_password" {
   length  = 16
   special = false
 }
+
+resource "random_string" "mongodb_monitoring_user" {
+  length  = 8
+  special = false
+  numeric = false
+}
+
+resource "random_password" "mongodb_monitoring_password" {
+  length  = 16
+  special = false
+}

--- a/storage/atlas/main.tf
+++ b/storage/atlas/main.tf
@@ -20,6 +20,30 @@ resource "mongodbatlas_database_user" "admin" {
     type = "CLUSTER"
   }
 }
+
+resource "mongodbatlas_database_user" "monitoring" {
+  username           = random_string.mongodb_monitoring_user.result
+  password           = random_password.mongodb_monitoring_password.result
+  project_id         = var.project_id
+  auth_database_name = "admin"
+
+  roles {
+    role_name     = "read"
+    database_name = "local"
+  }
+
+  roles {
+    role_name     = "clusterMonitor"
+    database_name = "admin"
+  }
+
+
+  scopes {
+    name = var.cluster_name
+    type = "CLUSTER"
+  }
+}
+
 data "mongodbatlas_advanced_cluster" "akaws" {
   project_id = var.project_id
   name       = var.cluster_name

--- a/storage/atlas/outputs.tf
+++ b/storage/atlas/outputs.tf
@@ -24,6 +24,10 @@ output "env_from_secret" {
       secret = kubernetes_secret.mongodbatlas_connection_string.metadata[0].name
       field  = "string"
     }
+    "MongoDB__MonitoringConnectionString" = {
+      secret = kubernetes_secret.mongodbatlas_monitoring_connection_string.metadata[0].name
+      field  = "uri"
+    }
   }
 }
 

--- a/storage/atlas/secrets.tf
+++ b/storage/atlas/secrets.tf
@@ -20,6 +20,16 @@ resource "kubernetes_secret" "mongodbatlas_connection_string" {
   }
 }
 
+resource "kubernetes_secret" "mongodbatlas_monitoring_connection_string" {
+  metadata {
+    name      = "mongodb-monitoring-connection-string"
+    namespace = var.namespace
+  }
+  data = {
+    uri = "mongodb+srv://${random_string.mongodb_monitoring_user.result}:${random_password.mongodb_monitoring_password.result}@${local.mongodb_url.dns}/admin"
+  }
+}
+
 resource "kubernetes_secret" "mongodb" {
   metadata {
     name      = "${var.cluster_name}-mongodb"

--- a/storage/onpremise/mongodb-sharded/certificates.tf
+++ b/storage/onpremise/mongodb-sharded/certificates.tf
@@ -39,6 +39,15 @@ resource "tls_cert_request" "mongodb_cert_request" {
     common_name = local.mongodb_dns
     # organization = "127.0.0.1"
   }
+
+  dns_names = [
+    local.mongodb_dns,
+    var.name,
+    "${var.name}.${var.namespace}",
+    "${var.name}.${var.namespace}.svc",
+    "${var.name}.${var.namespace}.svc.cluster.local",
+    "localhost"
+  ]
 }
 
 resource "tls_locally_signed_cert" "mongodb_certificate" {

--- a/storage/onpremise/mongodb-sharded/configmap.tf
+++ b/storage/onpremise/mongodb-sharded/configmap.tf
@@ -1,5 +1,22 @@
 locals {
   database_init_script = <<EOF
+    // Create users in admin database
+    db = db.getSiblingDB("admin");
+    
+    // Create monitoring user in admin database
+    db.createUser(
+    {
+        user: "${random_string.mongodb_monitoring_user.result}",
+        pwd: "${random_password.mongodb_monitoring_password.result}",
+        roles: [ 
+          { role: "read", db: "local" }, 
+          { role: "read", db: "database" },
+          { role: "clusterMonitor", db: "admin" },
+          { role: "read", db: "config" }
+        ]
+    }
+    );
+    
     db = db.getSiblingDB("${var.mongodb.database_name}");
     db.createCollection("sample")
     db.sample.insertOne({test:1})

--- a/storage/onpremise/mongodb-sharded/credentials.tf
+++ b/storage/onpremise/mongodb-sharded/credentials.tf
@@ -8,3 +8,14 @@ resource "random_password" "mongodb_application_password" {
   length  = 16
   special = false
 }
+
+resource "random_string" "mongodb_monitoring_user" {
+  length  = 8
+  special = false
+  numeric = false
+}
+
+resource "random_password" "mongodb_monitoring_password" {
+  length  = 16
+  special = false
+}

--- a/storage/onpremise/mongodb-sharded/outputs.tf
+++ b/storage/onpremise/mongodb-sharded/outputs.tf
@@ -78,5 +78,13 @@ output "env_from_secret" {
       secret = kubernetes_secret.mongodb_admin.metadata[0].name
       field  = "MONGO_PASSWORD"
     }
+    "MongoDB__ConnectionString" = {
+      secret = kubernetes_secret.mongodb_connection_string.metadata[0].name
+      field  = "uri"
+    }
+    "MongoDB__MonitoringConnectionString" = {
+      secret = kubernetes_secret.mongodb_monitoring_connection_string.metadata[0].name
+      field  = "uri"
+    }
   }
 }

--- a/storage/onpremise/mongodb-sharded/secrets.tf
+++ b/storage/onpremise/mongodb-sharded/secrets.tf
@@ -29,6 +29,26 @@ resource "kubernetes_secret" "mongodb_user" {
   }
 }
 
+resource "kubernetes_secret" "mongodb_monitoring_connection_string" {
+  metadata {
+    name      = "mongodb-monitoring-connection-string"
+    namespace = var.namespace
+  }
+  data = {
+    uri = "mongodb://${random_string.mongodb_monitoring_user.result}:${random_password.mongodb_monitoring_password.result}@${local.mongodb_dns}:27017/admin?tls=true&tlsAllowInvalidCertificates=true&tlsAllowInvalidHostnames=true&tlsCAFile=/mongodb/certs/ca.pem&authSource=admin"
+  }
+}
+
+resource "kubernetes_secret" "mongodb_connection_string" {
+  metadata {
+    name      = "mongodb-connection-string"
+    namespace = var.namespace
+  }
+  data = {
+    uri = "mongodb+srv://root:${local.mongodb_root_password}@${local.mongodb_dns}/${var.mongodb.database_name}?authSource=admin"
+  }
+}
+
 resource "kubernetes_secret" "mongodb" {
   metadata {
     name      = "custom-${var.name}"

--- a/storage/onpremise/mongodb/README.md
+++ b/storage/onpremise/mongodb/README.md
@@ -29,13 +29,17 @@ No modules.
 | [helm_release.mongodb](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
 | [kubernetes_secret.mongodb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.mongodb_admin](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.mongodb_connection_string](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
+| [kubernetes_secret.mongodb_monitoring_connection_string](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_secret.mongodb_user](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/secret) | resource |
 | [kubernetes_storage_class.mongodb](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/storage_class) | resource |
 | [local_sensitive_file.mongodb_client_certificate](https://registry.terraform.io/providers/hashicorp/local/latest/docs/resources/sensitive_file) | resource |
 | [random_password.mongodb_admin_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_password.mongodb_application_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
+| [random_password.mongodb_monitoring_password](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/password) | resource |
 | [random_string.mongodb_admin_user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [random_string.mongodb_application_user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
+| [random_string.mongodb_monitoring_user](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/string) | resource |
 | [kubernetes_secret.mongodb_certificates](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/data-sources/secret) | data source |
 
 ## Inputs

--- a/storage/onpremise/mongodb/createClusterMonitor.tftpl
+++ b/storage/onpremise/mongodb/createClusterMonitor.tftpl
@@ -1,7 +1,7 @@
 use admin;
 db.createUser({
-  user: "mongodb_exporter",
-  pwd: "mongodb_exporter",
+  user: "${username}",
+  pwd: "${password}",
   roles: [
     { role: "clusterMonitor", db: "admin"},
     { role: "read", db: "local"}

--- a/storage/onpremise/mongodb/credentials.tf
+++ b/storage/onpremise/mongodb/credentials.tf
@@ -20,6 +20,17 @@ resource "random_password" "mongodb_application_password" {
   special = false
 }
 
+resource "random_string" "mongodb_monitoring_user" {
+  length  = 8
+  special = false
+  numeric = false
+}
+
+resource "random_password" "mongodb_monitoring_password" {
+  length  = 16
+  special = false
+}
+
 resource "kubernetes_secret" "mongodb_admin" {
   metadata {
     name      = "mongodb-admin"
@@ -42,4 +53,14 @@ resource "kubernetes_secret" "mongodb_user" {
     password = random_password.mongodb_application_password.result
   }
   type = "kubernetes.io/basic-auth"
+}
+
+resource "kubernetes_secret" "mongodb_monitoring_connection_string" {
+  metadata {
+    name      = "mongodb-monitoring-connection-string"
+    namespace = var.namespace
+  }
+  data = {
+    uri = "mongodb://${random_string.mongodb_monitoring_user.result}:${random_password.mongodb_monitoring_password.result}@${local.mongodb_dns}:27017/admin?tls=true&tlsAllowInvalidCertificates=true&tlsAllowInvalidHostnames=true&tlsCAFile=/mongodb/certificate/mongodb-ca-cert&authSource=admin"
+  }
 }

--- a/storage/onpremise/mongodb/main.tf
+++ b/storage/onpremise/mongodb/main.tf
@@ -49,8 +49,7 @@ resource "helm_release" "mongodb" {
         "databases" = ["database"]
       }
       "initdbScripts" = {
-        "createClusterMonitor.js" = file("${path.module}/createClusterMonitor.js")
-      }
+      "createClusterMonitor.js" = templatefile("${path.module}/createClusterMonitor.tftpl", { username = random_string.mongodb_monitoring_user.result, password = random_password.mongodb_monitoring_password.result }) }
       "podSecurityContext" = {
         "fsGroup" = var.security_context.fs_group
       }

--- a/storage/onpremise/mongodb/outputs.tf
+++ b/storage/onpremise/mongodb/outputs.tf
@@ -86,5 +86,13 @@ output "env_from_secret" {
       secret = kubernetes_secret.mongodb_user.metadata[0].name
       field  = "password"
     }
+    "MongoDB_ConnectionString" = {
+      secret = kubernetes_secret.mongodb_connection_string.metadata[0].name
+      field  = "uri"
+    }
+    "MongoDB__MonitoringConnectionString" = {
+      secret = kubernetes_secret.mongodb_monitoring_connection_string.metadata[0].name
+      field  = "uri"
+    }
   }
 }

--- a/storage/onpremise/mongodb/secrets.tf
+++ b/storage/onpremise/mongodb/secrets.tf
@@ -5,6 +5,17 @@ data "kubernetes_secret" "mongodb_certificates" {
   }
 }
 
+resource "kubernetes_secret" "mongodb_connection_string" {
+
+  metadata {
+    name      = "mongodb-connection-string"
+    namespace = var.namespace
+  }
+  data = {
+    uri = "mongodb+srv://${random_string.mongodb_application_user.result}:${random_password.mongodb_application_password.result}@${local.mongodb_dns}/database"
+  }
+}
+
 resource "kubernetes_secret" "mongodb" {
   metadata {
     name      = "mongodb"


### PR DESCRIPTION
# Motivation

Making sure the previous exporter worked with Atlas MongoDB as well as needing to do various minor improvements. 

# Description

- Made changes to the `partitions-in-database` job and the `partitions-in-database` cron job. These used to fail when deploying sharded MongoDB on premise because the SRV record lookup isn't properly configured when deploying locally.  
- Added SAN for mongodb-sharded's certificate (Having only the common name specified results in a x509 error)
- Handled specific deployment requirements for 5 different ways of deploying MongoDB  
- Properly created the monitoring user in the different MongoDB deployments.
- Passing in the different modules instead of the URL for cleaner/easier deployment.

# Testing

This has been tested both locally and on AWS (See the PR that adds the exporter to the reference deployment). We assume that it should behave the same on GCP but given the issues caused by on-prem mongodb on localhost there could still be issues.

# Impact

Not Applicable (See reference deployment PR).

# Additional Information

The exporter doesn't work properly with on-prem sharded mongodb (It fails [here](https://github.com/percona/mongodb_exporter/blob/06b081abc942b244321ed5b5faeb76fde75c556f/exporter/exporter.go#L202)). This should be investigated further but I believe it's an issue with the exporter itself.  

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.