### PR TITLE
fix: init job authentication

### DIFF
--- a/armonik/locals.tf
+++ b/armonik/locals.tf
@@ -188,5 +188,5 @@ locals {
 
   job_init           = var.init != null
   job_partitions     = var.job_partitions_in_database != null
-  job_authentication = local.authentication_require_authentication && can(coalesce(var.authentication.name)) && can(coalesce(var.authentication.image)) && can(coalesce(var.authentication.tag))
+  job_authentication = local.authentication_require_authentication && can(coalesce(var.authentication.name))
 }


### PR DESCRIPTION
# Motivation

When deploying on GCP, we discovered that the check used to select the deployment type (on-premise vs. cloud) was not compatible with cloud environments. The variables required for the comparison are only readable after deployment, making the check ineffective.

# Description

Applied a hotfix by removing the comparison to allow deployments to proceed.

# Testing

Successfully deployed on both GCP.

# Impact

Both AWS and GCP deployments now work.

# Additional Information

This is a temporary hotfix. A proper solution should be implemented later to handle the deployment type comparison correctly.