### PR TITLE
chore: control plane service now starts without its deployment

### DIFF
--- a/armonik/control-plane.tf
+++ b/armonik/control-plane.tf
@@ -2,11 +2,11 @@
 resource "kubernetes_deployment" "control_plane" {
   depends_on = [kubernetes_job.init]
   metadata {
-    name      = "control-plane"
-    namespace = var.namespace
+    name      = local.control_plane_name
+    namespace = local.control_plane_namespace
     labels = {
-      app     = "armonik"
-      service = "control-plane"
+      app     = local.control_plane_labels.app
+      service = local.control_plane_labels.service
     }
   }
   spec {
@@ -19,11 +19,11 @@ resource "kubernetes_deployment" "control_plane" {
     }
     template {
       metadata {
-        name      = "control-plane"
-        namespace = var.namespace
+        name      = local.control_plane_name
+        namespace = local.control_plane_namespace
         labels = {
-          app     = "armonik"
-          service = "control-plane"
+          app     = local.control_plane_labels.app
+          service = local.control_plane_labels.service
         }
         annotations = local.control_plane_annotations
       }
@@ -92,12 +92,12 @@ resource "kubernetes_deployment" "control_plane" {
             requests = var.control_plane.requests
           }
           port {
-            name           = "control-port"
-            container_port = 1080
+            name           = local.control_plane_port.name
+            container_port = local.control_plane_port.container_port
           }
           port {
-            name           = "metrics-port"
-            container_port = 1081
+            name           = local.control_plane_port_metrics.name
+            container_port = local.control_plane_port_metrics.container_port
           }
           liveness_probe {
             http_get {
@@ -288,11 +288,11 @@ resource "kubernetes_deployment" "control_plane" {
 # Control plane service
 resource "kubernetes_service" "control_plane" {
   metadata {
-    name      = kubernetes_deployment.control_plane.metadata[0].name
-    namespace = kubernetes_deployment.control_plane.metadata[0].namespace
+    name      = local.control_plane_name
+    namespace = local.control_plane_namespace
     labels = {
-      app     = kubernetes_deployment.control_plane.metadata[0].labels.app
-      service = kubernetes_deployment.control_plane.metadata[0].labels.service
+      app     = local.control_plane_labels.app
+      service = local.control_plane_labels.service
     }
     annotations = var.control_plane.annotations
   }
@@ -300,13 +300,13 @@ resource "kubernetes_service" "control_plane" {
     type       = var.control_plane.service_type == "HeadLess" ? "ClusterIP" : var.control_plane.service_type
     cluster_ip = var.control_plane.service_type == "HeadLess" ? "None" : null
     selector = {
-      app     = kubernetes_deployment.control_plane.metadata[0].labels.app
-      service = kubernetes_deployment.control_plane.metadata[0].labels.service
+      app     = local.control_plane_labels.app
+      service = local.control_plane_labels.service
     }
     port {
-      name        = kubernetes_deployment.control_plane.spec[0].template[0].spec[0].container[0].port[0].name
-      port        = var.control_plane.service_type == "HeadLess" ? kubernetes_deployment.control_plane.spec[0].template[0].spec[0].container[0].port[0].container_port : var.control_plane.port
-      target_port = kubernetes_deployment.control_plane.spec[0].template[0].spec[0].container[0].port[0].container_port
+      name        = local.control_plane_port.name
+      port        = var.control_plane.service_type == "HeadLess" ? local.control_plane_port.container_port: var.control_plane.port
+      target_port = local.control_plane_port.container_port
       protocol    = "TCP"
     }
   }

--- a/armonik/locals.tf
+++ b/armonik/locals.tf
@@ -163,6 +163,20 @@ locals {
   }
 
   # Control plane
+  control_plane_name = "control-plane"
+  control_plane_namespace = var.namespace
+  control_plane_labels = {
+    app = "armonik"
+    service = "control-plane"
+  }
+  control_plane_port = {
+    name = "control-port"
+    container_port = 1080
+  }
+  control_plane_port_metrics = {
+    name = "metrics-port"
+    container_port = 1081
+  }
   hpa_control_plane_triggers = {
     triggers = [
       for trigger in try(var.control_plane.hpa.triggers, []) :


### PR DESCRIPTION
# Motivation

Ingress was not created when the control_plane deployment failed to start. 

# Description

Created local variables that will be shared amongst control_plane deployment and service. Now, the service is not dependent from its deployment, and will always start even if the deployment fails. Since the ingress deployment needed only the control_plane service data (ip and port), it does not require more than this modification.

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.