### PR TITLE
refactor: Add protocol hint

### DIFF
--- a/armonik/control-plane.tf
+++ b/armonik/control-plane.tf
@@ -293,6 +293,8 @@ resource "kubernetes_service" "control_plane" {
       port        = var.control_plane.service_type == "HeadLess" ? local.control_plane_port.container_port : var.control_plane.port
       target_port = local.control_plane_port.container_port
       protocol    = "TCP"
+      # App protocol is required when it is http2 clear text to work properly with some gateway API controllers like on GCP
+      app_protocol = "kubernetes.io/h2c"
     }
   }
 }

--- a/armonik/ingress/main.tf
+++ b/armonik/ingress/main.tf
@@ -148,6 +148,8 @@ resource "kubernetes_service" "ingress" {
         target_port = local.target_ports[port.key]
         port        = var.nginx.service.type == "HeadLess" ? local.target_ports[port.key] : port.value
         protocol    = "TCP"
+        # App protocol is required when it is http2 clear text to work properly with some gateway API controllers like on GCP
+        app_protocol = var.tls != null ? null : "kubernetes.io/h2c"
       }
     }
   }


### PR DESCRIPTION
# Motivation

When configuring the gateway API on GCP, the HTTProute needs to know what protocol is targeted, when the protocol is HTTP2 cleartext.

# Description

Add `app_protocol = "kubernetes.io/h2c"` to HTTP2 services, namely ingress and control-plane.

# Testing

Gateway API has been successfully deployed in the customer environment using this annotation.

# Impact

None

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.