### PR TITLE
feat(armonik): add optional readiness probe for control-plane

### DIFF
--- a/armonik/control-plane.tf
+++ b/armonik/control-plane.tf
@@ -101,6 +101,20 @@ resource "kubernetes_deployment" "control_plane" {
             success_threshold     = 1
             failure_threshold     = 1
           }
+          dynamic "readiness_probe" {
+            for_each = var.control_plane.readiness_probe ? [1] : []
+            content {
+              http_get {
+                path = "/readiness"
+                port = 1081
+              }
+              initial_delay_seconds = 15
+              period_seconds        = 5
+              timeout_seconds       = 1
+              success_threshold     = 1
+              failure_threshold     = 1
+            }
+          }
           startup_probe {
             http_get {
               path = "/startup"

--- a/armonik/variables.tf
+++ b/armonik/variables.tf
@@ -115,6 +115,7 @@ variable "control_plane" {
     hpa                  = any
     default_partition    = string
     service_account_name = string
+    readiness_probe      = optional(bool, false)
   })
 }
 


### PR DESCRIPTION
# Motivation

This is the infrastructure follow-up to [ArmoniK.Core#1258](https://github.com/aneoconsulting/ArmoniK.Core/pull/1258), which makes the control plane (Submitter) shut down gracefully on too many errors and exposes an HTTP `/readiness` endpoint on the management port (`1081`).

That Core change is only useful once the orchestrator actually probes the new endpoint: the readiness/liveness probe wiring deliberately lives in the deployment/infra, not in ArmoniK.Core. This PR adds that wiring so Kubernetes can observe the control plane's readiness state, deregister an Unhealthy pod from the Service endpoints, and let the graceful drain run instead of cutting requests off mid-flight.

# Description

Adds an **optional** readiness probe to the `control_plane` Kubernetes deployment:

- `armonik/control-plane.tf`: introduces a `dynamic "readiness_probe"` block, gated on `var.control_plane.readiness_probe`. When enabled, it performs an HTTP GET on `/readiness` (port `1081`, the management port exposed by ArmoniK.Core#1258) with `initial_delay_seconds = 15`, `period_seconds = 5`, `timeout_seconds = 1`, `success_threshold = 1`, and `failure_threshold = 1`.
- `armonik/variables.tf`: adds a new `readiness_probe` field to the `control_plane` object variable, declared as `optional(bool, false)` so existing configurations remain unchanged.

The probe is disabled by default, so this is a backward-compatible, opt-in change that should only be enabled once the control-plane image includes the ArmoniK.Core#1258 changes (otherwise `/readiness` is not served).

# Testing

No automated tests were added; this is an infrastructure (Terraform) change. Validation can be performed with `terraform validate` / `terraform plan` and by enabling the flag in a test deployment to confirm the readiness probe is created and that the pod is correctly removed from Service endpoints when `/readiness` reports Unhealthy.

# Impact

- **Configuration**: new optional `control_plane.readiness_probe` boolean (defaults to `false`); no change required for existing deployments.
- **Behaviour**: when enabled, the control-plane pod is only added to Service endpoints once `/readiness` returns success, and is removed from rotation when it fails readiness, complementing the graceful self-termination introduced in ArmoniK.Core#1258.
- **Dependency / sequencing**: requires a control-plane image built from ArmoniK.Core#1258 (or later) for the `/readiness` endpoint to exist. Per that PR, deployments relying on the graceful drain should also ensure `terminationGracePeriodSeconds` covers `SelfTerminationDelay + GraceDelay`.
- **Performance**: negligible; one lightweight HTTP probe every 5 seconds when enabled.
- **Dependencies**: none new on the infra side.

# Additional Information

Follow-up to [ArmoniK.Core#1258](https://github.com/aneoconsulting/ArmoniK.Core/pull/1258).