### PR TITLE
fix(helm): resolve Helm chart installation issues

### DIFF
--- a/charts/armonik-compute-plane/templates/init.yaml
+++ b/charts/armonik-compute-plane/templates/init.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- include "armonik.labels" . | nindent 4 }}
 spec:
   backoffLimit: 5
+  ttlSecondsAfterFinished: 1
   completionMode: NonIndexed
   completions: 1
   manualSelector: false

--- a/charts/armonik-control-plane/templates/jobs/init.yaml
+++ b/charts/armonik-control-plane/templates/jobs/init.yaml
@@ -17,6 +17,7 @@ metadata:
     {{- include "armonik.labels" . | nindent 4 }}
 spec:
   backoffLimit: 5
+  ttlSecondsAfterFinished: 1
   completionMode: NonIndexed
   completions: 1
   manualSelector: false

--- a/charts/armonik/README.md
+++ b/charts/armonik/README.md
@@ -108,6 +108,7 @@ Kubernetes: `>=v1.25.0-0`
 | dependencies.kube-prometheus.fullnameOverride | string | `"prometheus"` |  |
 | dependencies.kube-prometheus.grafana.enabled | bool | `false` |  |
 | dependencies.kube-prometheus.prometheus-node-exporter.hostRootFsMount.enabled | bool | `false` |  |
+| dependencies.kube-prometheus.prometheus.prometheusSpec.additionalScrapeConfigsSecret.enabled | bool | `true` |  |
 | dependencies.kube-prometheus.prometheus.prometheusSpec.additionalScrapeConfigsSecret.key | string | `"prometheus-additional.yaml"` |  |
 | dependencies.kube-prometheus.prometheus.prometheusSpec.additionalScrapeConfigsSecret.name | string | `"additional-scrape-configs"` |  |
 | dependencies.kube-prometheus.prometheus.prometheusSpec.evaluationInterval | string | `"30s"` |  |
@@ -126,7 +127,9 @@ Kubernetes: `>=v1.25.0-0`
 | dependencies.rabbitmq.auth.username | string | `"admin"` |  |
 | dependencies.rabbitmq.enabled | bool | `false` |  |
 | dependencies.rabbitmq.fullnameOverride | string | `"rabbitmq"` |  |
-| dependencies.rabbitmq.image.registry | string | `"public.ecr.aws"` |  |
+| dependencies.rabbitmq.image.registry | string | `"bitnamilegacy"` |  |
+| dependencies.rabbitmq.image.repository | string | `"rabbitmq"` |  |
+| dependencies.rabbitmq.image.tag | string | `"4.1.3"` |  |
 | dependencies.rabbitmq.metrics.enabled | bool | `true` |  |
 | dependencies.rabbitmq.metrics.image.registry | string | `"public.ecr.aws"` |  |
 | dependencies.rabbitmq.metrics.serviceMonitor.enabled | bool | `true` |  |

--- a/charts/armonik/static-confs/prometheus/config.yaml
+++ b/charts/armonik/static-confs/prometheus/config.yaml
@@ -1,16 +1,16 @@
 - job_name: "metrics-exporter"
   static_configs:
-    - targets: ["metrics-exporter:9419"]
+    - targets: ["armonik-control-plane-metrics-exporter.armonik.svc.cluster.local:9419"]
       labels:
         namespace: "armonik"
 
 - job_name: 'kube-state-metrics'
   static_configs:
-    - targets: ['kube-state-metrics:8080']
+    - targets: ['armonik-kube-state-metrics.armonik.svc.cluster.local:8080']
 
 - job_name: "mongodb-metrics-exporter"
   static_configs:
-    - targets: ["mongodb:27017"]
+    - targets: ["armonik-prometheus-mongodb-exporter:9216"]
       labels:
         namespace: "armonik"
   metrics_path: /metrics

--- a/charts/armonik/templates/secrets/prometheus-additional-scrape.yaml
+++ b/charts/armonik/templates/secrets/prometheus-additional-scrape.yaml
@@ -5,5 +5,5 @@ metadata:
   creationTimestamp: null
   name: additional-scrape-configs
 data:
-  prometheus-additional.yaml: {{ .Files.Get "static-confs/prometheus-conf/config.yaml" | b64enc }}
+  prometheus-additional.yaml: {{ .Files.Get "static-confs/prometheus/config.yaml" | b64enc }}
 {{ end }}

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -616,6 +616,7 @@ dependencies:
         evaluationInterval: 30s
         
         additionalScrapeConfigsSecret:
+          enabled: true
           name: additional-scrape-configs
           key: prometheus-additional.yaml
 ############################################

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -72,7 +72,9 @@ dependencies:
   ################# RABBITMQ #################
   rabbitmq:
     image:
-      registry: public.ecr.aws
+      registry: bitnamilegacy
+      repository: rabbitmq
+      tag: 4.1.3
     enabled: false
     fullnameOverride: "rabbitmq"
     auth:


### PR DESCRIPTION
# Motivation

fix helm install 

# Description

This PR fixes several issues that prevented a clean installation of the armonik chart :

- **Path typo:** the prometheus-additional-scrape.yaml secret referenced static-confs/prometheus-conf/config.yam, fixed to static-confs/prometheus/config.yaml.

- **Incorrect static Prometheus scrape targets:** static-confs/prometheus/config.yaml pointed to generic service names (metrics-exporter:9419, kube-state-metrics:8080, mongodb:27017) that don't match any actual service in the cluster. Replaced with the real Kubernetes FQDNs (armonik-control-plane-metrics-exporter.armonik.svc.cluster.local:9419, armonik-kube-state-metrics.armonik.svc.cluster.local:8080, armonik-prometheus-mongodb-exporter:9216).

- **additionalScrapeConfigsSecret** not enabled: added enabled: true in values.yaml so the additional scrape config secret is actually mounted by Prometheus (otherwise the static jobs above were never picked up).

- **RabbitMQ registry:** switched from public.ecr.aws to bitnamilegacy for the RabbitMQ image, since the image was no longer available on public.ecr.aws.

- **Init jobs left lingering:** added ttlSecondsAfterFinished: 1 to the init Jobs in armonik-compute-plane and armonik-control-plane, so completed Job pods are cleaned up automatically instead of persisting and potentially blocking reinstalls.

# Testing

[When applicable, detail the testing you have performed to ensure that these changes function as intended. Include information about any added tests.]

# Impact

These fixes restore Prometheus metrics visibility for the control-plane which unblocks HPA-based autoscaling, previously jobs couldn't scale because the relevant metrics weren't being scraped at all. 

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [ ] My code adheres to the coding and style guidelines of the project.
- [ ] I have performed a self-review of my code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
- [ ] I have made corresponding changes to the documentation.
- [ ] I have thoroughly tested my modifications and added tests when necessary.
- [ ] Tests pass locally and in the CI.
- [ ] I have assessed the performance impact of my modifications.