### PR TITLE
fix(helm): restore grafana links and redirects behind the ingress prefix

### DIFF
--- a/charts/armonik-ingress/templates/configmaps/nginx.yaml
+++ b/charts/armonik-ingress/templates/configmaps/nginx.yaml
@@ -153,24 +153,36 @@ data:
             sub_filter_once on;
             proxy_hide_header content-security-policy;
         }
+        {{- /* Grafana runs with a path-less root_url and never learns its public path: we inject it
+               below, so one Grafana serves under any prefix. Per-cluster: derive from the cluster key. */}}
+        {{- $grafanaPath := "/grafana" }}
         set $grafana_upstream http://grafana.{{ $svcSuffix }};
-        location = /grafana {
-            rewrite ^ $scheme://$http_host/grafana/ permanent;
+        location = {{ $grafanaPath }} {
+            rewrite ^ $real_scheme://$http_host{{ $grafanaPath }}/ permanent;
         }
-        location /grafana/ {
+        location {{ $grafanaPath }}/ {
             proxy_set_header Host $http_host;
+            # sub_filter needs an uncompressed body
             proxy_set_header Accept-Encoding "";
-            rewrite  ^/grafana/(.*)  /$1 break;
+            rewrite  ^{{ $grafanaPath }}/(.*)  /$1 break;
             proxy_pass $grafana_upstream$uri$is_args$args;
-            sub_filter '<head>' '<head><base href="${real_scheme}://${http_host}/grafana/">';
+
+            # <base> covers Grafana's relative URLs (assets, API), appSubUrl the absolute ones it
+            # builds itself. Literal matches, so both need a path-less root_url: guarded in the
+            # umbrella (armonik/templates/validate.yaml). Checked against grafana 11.6.1.
+            sub_filter '<base href="/" />' '<base href="{{ $grafanaPath }}/" />';
+            sub_filter '"appSubUrl":""'    '"appSubUrl":"{{ $grafanaPath }}"';
             sub_filter_once on;
-            proxy_intercept_errors on;
-            error_page 301 302 307 =302 ${scheme}://${http_host}${upstream_http_location};
+
+            # Same for Location headers, relative or upstream-absolute.
+            proxy_redirect  /                   $real_scheme://$http_host{{ $grafanaPath }}/;
+            proxy_redirect  $grafana_upstream/  $real_scheme://$http_host{{ $grafanaPath }}/;
         }
-        location /grafana/api/live {
+        location {{ $grafanaPath }}/api/live {
             proxy_set_header Host $http_host;
-            rewrite  ^/grafana/(.*)  /$1 break;
+            rewrite  ^{{ $grafanaPath }}/(.*)  /$1 break;
             proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
             proxy_set_header Connection $connection_upgrade;
             proxy_pass $grafana_upstream$uri$is_args$args;
         }

--- a/charts/armonik/README.md
+++ b/charts/armonik/README.md
@@ -84,10 +84,9 @@ Kubernetes: `>=v1.25.0-0`
 | dependencies.fluent-bit.enabled | bool | `true` |  |
 | dependencies.fluent-bit.fullnameOverride | string | `"fluent-bit"` |  |
 | dependencies.grafana."grafana.ini"."auth.anonymous".enabled | bool | `true` |  |
-| dependencies.grafana."grafana.ini".anonymous.enabled | bool | `true` |  |
 | dependencies.grafana."grafana.ini".server.domain | string | `"grafana.local"` |  |
 | dependencies.grafana."grafana.ini".server.root_url | string | `"http://grafana"` |  |
-| dependencies.grafana."grafana.ini".server.serve_from_sub_path | bool | `true` |  |
+| dependencies.grafana."grafana.ini".server.serve_from_sub_path | bool | `false` |  |
 | dependencies.grafana.enabled | bool | `true` |  |
 | dependencies.grafana.fullnameOverride | string | `"grafana"` |  |
 | dependencies.grafana.image.registry | string | `"docker.io"` |  |

--- a/charts/armonik/templates/validate.yaml
+++ b/charts/armonik/templates/validate.yaml
@@ -1,0 +1,18 @@
+{{- /* The ingress injects Grafana's public prefix into its output (armonik-ingress
+       templates/configmaps/nginx.yaml) and needs an empty appSubUrl to do so. Breaking that
+       breaks the UI with no error anywhere, hence a render-time guard. */ -}}
+{{- $grafanaEnabled := list .Values "dependencies" "grafana" "enabled" | include "armonik.utils.index" | empty | not -}}
+{{- $ingressEnabled := list .Values "ingress" "enabled" | include "armonik.utils.index" | empty | not -}}
+{{- if and $grafanaEnabled $ingressEnabled -}}
+  {{- $server := list .Values "dependencies" "grafana" "grafana.ini" "server" | include "armonik.utils.index" | fromYaml | default dict -}}
+  {{- $rootUrl := $server.root_url | default "" | toString -}}
+  {{- /* appSubUrl is root_url's path. */ -}}
+  {{- $parts := splitList "://" $rootUrl | last | splitn "/" 2 -}}
+  {{- $path := $parts._1 | default "" | trimSuffix "/" -}}
+  {{- if $path -}}
+    {{- printf `dependencies.grafana."grafana.ini".server.root_url must not carry a path, got %q: armonik-ingress injects Grafana's public prefix itself and needs an empty appSubUrl. Drop the %q segment, or set ingress.enabled=false to proxy Grafana yourself.` $rootUrl $path | fail -}}
+  {{- end -}}
+  {{- if $server.serve_from_sub_path -}}
+    {{- fail `dependencies.grafana."grafana.ini".server.serve_from_sub_path must stay false: armonik-ingress strips the prefix before proxying, so Grafana keeps serving at "/".` -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -248,11 +248,12 @@ dependencies:
     fullnameOverride: "grafana"
     grafana.ini:
       server:
+        # Keep root_url path-less and serve_from_sub_path false: the ingress publishes Grafana
+        # under a prefix it injects itself (armonik-ingress templates/configmaps/nginx.yaml),
+        # which needs an empty appSubUrl. Enforced by armonik/templates/validate.yaml.
         domain: grafana.local
         root_url: http://grafana
-        serve_from_sub_path: true
-      anonymous:
-        enabled: true
+        serve_from_sub_path: false
       auth.anonymous:
         enabled: true
     sidecar:


### PR DESCRIPTION
# Motivation

Grafana broke behind the ingress during the Helm revamp: typing the URL worked, but every link and redirect Grafana produced dropped the `/grafana/` prefix. The Terraform ingress reverse-proxies Grafana the same way without the problem.

Root cause is `dependencies.grafana."grafana.ini".server.root_url`, which was `http://grafana`, i.e. no path. Grafana derives `appSubUrl` from root_url's path and nothing else ([`setting.go:578-594`](https://github.com/grafana/grafana/blob/v11.6.1/pkg/setting/setting.go#L578)), independently of `serve_from_sub_path`, so `appSubUrl` was empty and everything the frontend built was rooted at `/`. `serve_from_sub_path: true` was also the wrong half of the pair, since the nginx conf strips the prefix before proxying; it was inert only because `appSubUrl` was empty.

# Description

Putting the prefix into `root_url` would fix it, but it forces every Grafana to know the path it is published under, which does not hold for a shared ingress and would hard-code the prefix ahead of cluster-scoped paths. So the ingress injects the prefix into Grafana's output instead, and Grafana keeps a path-less `root_url`.

Grafana emits two kinds of URL and each needs its own injection:

| Emitted | Source | Injection |
|---|---|---|
| Assets, API calls | relative, resolved against `<base>` ([`index.html:15`](https://github.com/grafana/grafana/blob/v11.6.1/public/views/index.html#L15); [`backend_srv.ts:274-275`](https://github.com/grafana/grafana/blob/v11.6.1/public/app/core/services/backend_srv.ts#L274) strips the leading `/`) | `sub_filter` on `<base href="/" />` |
| Links, in-app redirects | absolute paths from `config.appSubUrl` ([`assureBaseUrl`](https://github.com/grafana/grafana/blob/v11.6.1/packages/grafana-data/src/utils/location.ts#L60)) | `sub_filter` on `"appSubUrl":""` in the boot data |
| `Location` headers | server-side | `proxy_redirect` |

Also in this change:

- Removed `proxy_intercept_errors` + `error_page 301 302 307`, superseded by `proxy_redirect`. The old line turned an absolute upstream `Location` into `https://host/http://...`.
- Added the missing `proxy_set_header Upgrade $http_upgrade` on `/grafana/api/live`. Without it the Grafana Live websocket handshake cannot complete.
- The prefix now comes from a single `$grafanaPath` template variable feeding the location, rewrite, both `sub_filter`s and both `proxy_redirect`s, so a cluster-scoped prefix becomes a one-line change once multi-cluster HTTP routing lands next to the `grafanaUrl`/`seqUrl` keys already reserved in `load-balancer.yaml`.
- New `charts/armonik/templates/validate.yaml` fails the render if `root_url` gains a path or `serve_from_sub_path` is turned on, gated on Grafana and the ingress both being enabled.
- Dropped a stray `dependencies.grafana."grafana.ini".anonymous.enabled` key. It is not a Grafana section; `auth.anonymous` is the real one and is unchanged.

# Testing

Manual: there is no chart test suite yet, so this is `helm lint` / `helm template` plus a container run of the rendered output.

- `helm lint armonik` passes; the rendered `armonik.conf` passes `nginx -t`.
- Ran the **rendered chart config** in nginx 1.27 against a real `grafana/grafana:11.6.1` with a default path-less `root_url`:
  - `/grafana` -> `301` to `/grafana/`
  - index serves `<base href="/grafana/" />` and `"appSubUrl":"/grafana"`
  - `public/build/app.<hash>.js` -> `200`; `api/health`, `api/frontend/settings`, `api/search` -> `200`
  - `api/live/ws` -> `101 Switching Protocols`
  - with auth enabled, upstream `Location: /login` comes out as `http://host/grafana/login`, and `/grafana/profile` as `.../grafana/login?redirectTo=%2Fprofile`
- Repeated the same setup under `/local/grafana/` to confirm the prefix is arbitrary, which is what makes cluster-scoped prefixes work later.
- Guard: fires on a `root_url` with a path (with and without trailing slash, and in `%(protocol)s://...` form) and on `serve_from_sub_path=true`; stays silent on the shipped values, `root_url` unset, trailing-slash-only, `host:port` with no path, Grafana disabled, and ingress disabled even with a path in `root_url`.

# Impact

- **Behaviour**: Grafana is usable behind the ingress again, and Grafana Live websockets work.
- **Configuration**: `root_url` and `serve_from_sub_path` in the umbrella values are now constrained rather than free-form, enforced at render time with an actionable message.
- **Maintenance risk, worth flagging**: the two `sub_filter` targets are literal strings from Grafana's HTML and boot data, which are not a public API. A Grafana upgrade that reformats either breaks the UI **silently**, with nothing in any log. Verified against 11.6.1 and noted in the template comment; worth adding to the checklist for Grafana dependency bumps. A `semverCompare` guard on the subchart `appVersion` could force a re-verify on every bump if we want that trade-off.
- No new dependencies. `charts/armonik/README.md` regenerated by helm-docs.

# Additional Information

Two pre-existing issues found while working on this and deliberately left out of scope:

- The nginx conf hardcodes `grafana.<ns>.svc.<domain>` and `seq.<ns>...`, which only works because of `fullnameOverride: "grafana"`. This violates the "no hardcoded service names" contract in `CLAUDE.md` and deserves being derived from `.Subcharts` rather than pinned by a guard.
- The `/admin` and `/seq` redirects still use `$scheme` instead of the `$real_scheme` map, so behind an external TLS terminator they downgrade the client to `http`. The Grafana block no longer has this.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary. (No chart test suite exists yet; validated as described above.)
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications. (`sub_filter` disables gzip from the upstream and rewrites the body, on the Grafana HTML document only; assets and API responses are untouched.)
