### PR TITLE
build(charts): add build and refresh modes to update-charts.sh

### DIFF
--- a/charts/update-charts.sh
+++ b/charts/update-charts.sh
@@ -1,10 +1,83 @@
 #! /bin/sh
 
+# Re-vendors the dependencies of every chart in this directory.
+#
+# Charts are processed in layers: a layer's charts are packaged into the
+# charts/ of the next layer, so the layers run in order while the charts of a
+# single layer run in parallel.
+
+set -eu
+
+self="$0"
+cd "$(dirname "$self")"
+
+usage() {
+  cat <<EOF
+Usage: $self [-u] [-r] [-h]
+
+Re-vendors the dependencies of every chart, cheapest mode first:
+
+  $self          helm dependency build  --skip-refresh
+  $self -r       helm dependency build
+  $self -u       helm dependency update --skip-refresh
+  $self -u -r    helm dependency update
+
+  -u  re-resolve the dependencies and rewrite Chart.lock, instead of
+      reproducing the versions it already pins
+  -r  refresh the local repository cache before resolving
+  -h  show this help
+EOF
+}
+
+action=build
+refresh=0
+
+while getopts ':urh' opt; do
+  case "$opt" in
+    u) action=update ;;
+    r) refresh=1 ;;
+    h) usage; exit 0 ;;
+    *)
+      printf '%s: invalid option -- %s\n\n' "$self" "$OPTARG" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+shift $((OPTIND - 1))
+
+if [ "$#" -gt 0 ]; then
+  printf "%s: unexpected argument '%s': this script re-vendors every chart\n" "$self" "$1" >&2
+  exit 2
+fi
+
+helm_opts=$action
+[ "$refresh" -eq 1 ] || helm_opts="$helm_opts --skip-refresh"
+
 updatedeps() {
+  running=
   for chart in "$@"; do
-    helm dependency update "$chart" --skip-refresh &
+    # Word splitting of helm_opts is wanted; it only ever holds literal flags.
+    helm dependency $helm_opts "$chart" &
+    running="$running $!:$chart"
   done
-  wait
+
+  # `wait` without operand always reports success, so every job is waited on
+  # individually to catch the ones that failed.
+  failed=
+  for job in $running; do
+    if ! wait "${job%%:*}"; then
+      failed="$failed ${job#*:}"
+    fi
+  done
+
+  # A layer feeds the next one, so a failure here stops everything.
+  if [ -n "$failed" ]; then
+    printf '%s: failed to vendor:%s\n' "$self" "$failed" >&2
+    [ "$action" = update ] || printf '%s: hint: a Chart.lock out of sync with its Chart.yaml needs -u\n' "$self" >&2
+    [ "$refresh" -eq 1 ] || printf '%s: hint: a missing or stale repository index needs -r\n' "$self" >&2
+    exit 1
+  fi
 }
 
 updatedeps activemq armonik-common

--- a/charts/update-charts.sh
+++ b/charts/update-charts.sh
@@ -5,6 +5,10 @@
 # Charts are processed in layers: a layer's charts are packaged into the
 # charts/ of the next layer, so the layers run in order while the charts of a
 # single layer run in parallel.
+#
+# A dependency repository absent from `helm repo list` (helm calls it
+# unmanaged) is only ever fetched by `dependency update` while it refreshes, so
+# -u -r is the one mode that needs no `helm repo add` beforehand.
 
 set -eu
 
@@ -24,7 +28,8 @@ Re-vendors the dependencies of every chart, cheapest mode first:
 
   -u  re-resolve the dependencies and rewrite Chart.lock, instead of
       reproducing the versions it already pins
-  -r  refresh the local repository cache before resolving
+  -r  refresh the local repository cache; the charts pulling from a repository
+      then run one at a time, the others stay parallel
   -h  show this help
 EOF
 }
@@ -51,31 +56,47 @@ if [ "$#" -gt 0 ]; then
   exit 2
 fi
 
-helm_opts=$action
-[ "$refresh" -eq 1 ] || helm_opts="$helm_opts --skip-refresh"
+# Word splitting of both is wanted; they only ever hold literal flags.
+cached_opts="$action --skip-refresh"
+refresh_opts=$action
+
+# Only a chart pulling a dependency from an http(s) repository reads the shared
+# repository index, and refreshes it when told to; one that resolves everything
+# from file:// or an OCI registry never opens it.
+usesrepos() {
+  grep -qE '^[[:space:]]*repository:[[:space:]]*"?https?://' "$1/Chart.yaml"
+}
 
 updatedeps() {
   running=
+  failed=
+  cached=
   for chart in "$@"; do
-    # Word splitting of helm_opts is wanted; it only ever holds literal flags.
-    helm dependency $helm_opts "$chart" &
+    if [ "$refresh" -eq 1 ] && usesrepos "$chart"; then
+      # A refresh rewrites the whole index and helm offers no way to refresh it
+      # separately, so these run one at a time, before anything reads it.
+      helm dependency $refresh_opts "$chart" || failed="$failed $chart"
+    else
+      cached="$cached $chart"
+    fi
+  done
+
+  for chart in $cached; do
+    helm dependency $cached_opts "$chart" &
     running="$running $!:$chart"
   done
 
   # `wait` without operand always reports success, so every job is waited on
   # individually to catch the ones that failed.
-  failed=
   for job in $running; do
-    if ! wait "${job%%:*}"; then
-      failed="$failed ${job#*:}"
-    fi
+    wait "${job%%:*}" || failed="$failed ${job#*:}"
   done
 
   # A layer feeds the next one, so a failure here stops everything.
   if [ -n "$failed" ]; then
     printf '%s: failed to vendor:%s\n' "$self" "$failed" >&2
     [ "$action" = update ] || printf '%s: hint: a Chart.lock out of sync with its Chart.yaml needs -u\n' "$self" >&2
-    [ "$refresh" -eq 1 ] || printf '%s: hint: a missing or stale repository index needs -r\n' "$self" >&2
+    [ "$refresh" -eq 1 ] || printf '%s: hint: a stale repository index needs -r, one absent from `helm repo list` needs -u -r\n' "$self" >&2
     exit 1
   fi
 }


### PR DESCRIPTION
# Motivation

`charts/update-charts.sh` hardcoded one mode for every chart, so switching between reproducing `Chart.lock` and re-resolving it meant editing the script (the alternative was sitting there commented out). Two problems came with it:

- Failures were silent. The script backgrounded every chart and then called bare `wait`, which always exits 0 in POSIX sh, so a failing `helm dependency` was reported as a successful run.
- Refreshing in parallel corrupts the repository cache. Any `helm dependency build`/`update` that is not given `--skip-refresh` rewrites *every* index in the shared cache, whatever the chart actually depends on, so N charts in parallel means N processes rewriting the same files at once.

# Description

The script now takes `[-u] [-r]`, two orthogonal flags, cheapest mode first:

| invocation | per chart |
| --- | --- |
| `./update-charts.sh` | `helm dependency build --skip-refresh` |
| `-r` | `helm dependency build` |
| `-u` | `helm dependency update --skip-refresh` |
| `-u -r` | `helm dependency update` |

- `-u` re-resolves the ranges and rewrites `Chart.lock`; without it the run reproduces the pinned versions.
- `-r` refreshes the repository cache. Only the charts that pull a dependency from an http(s) repository read or rewrite that cache, so those run one at a time while the rest keep going in parallel with `--skip-refresh`. The check is per-chart (a `grep` over the `repository:` entries), so `armonik-operators` is picked up automatically once it lands, with no list to maintain. `oci://` dependencies count as parallel-safe: they resolve through the registry, not the index.
- Failures are caught: every job is waited on by pid, failing charts are listed by name, and the run stops before the next layer, since a layer is packaged into the one above it. The exit status is 1, and the message carries mode-aware hints (`-u` for a `Chart.lock` out of sync with its `Chart.yaml`, `-r` for a stale index, `-u -r` for a repository absent from `helm repo list`).
- The layers themselves are unchanged, and so is the parallelism inside a layer for the two modes that do not refresh.
- Housekeeping: `-h` prints the usage, an unexpected positional argument is rejected rather than mistaken for a chart filter, and the script `cd`s to its own directory so it no longer has to be invoked from `charts/`.

# Testing

No test suite covers this script, so it was exercised by hand against helm 3.18.4:

- A stub `helm` on `PATH` confirms the exact command line of all four flag combinations, that `-r`/`-u -r` serialize only `armonik-dependencies`, and that an injected failure is reported by name with the following layer skipped (exit 1).
- Real runs against the working tree: default 37s, `-r` 43s (fully serializing the refresh instead would have cost 65s), `-u -r` re-resolves and rewrites the locks as expected. `Chart.lock` is untouched by the two `build` modes.
- Fresh-machine simulation (copy of `charts/`, empty `HELM_REPOSITORY_CONFIG`, cold cache, all `.tgz` deleted): `-u -r` vendors everything in 22s through helm's unmanaged-repository path; the other modes fail with helm's own `no repository definition ... Please add the missing repos via 'helm repo add'`.
- The refresh behaviour was verified directly: with an index file's mtime forced to 2020-01-01, `helm dependency update` on a chart whose only dependency is `file://` rewrites it, while the same run with `--skip-refresh` leaves it alone. That is what the split is built on.

# Impact

- **Behaviour change for contributors**: the default is now `build --skip-refresh` (reproduce `Chart.lock`) where the committed script did `update --skip-refresh`. Editing the content of a local chart still needs nothing but a bare run, which re-packages it as it is; changing a `Chart.yaml` needs `-u` (detailed below), and picking up newly published versions of a third-party chart needs `-u -r`. Nothing else in the repo invokes the script.
- No effect on rendered charts: the script only vendors dependencies.
- On a machine that has not added the dependency repositories (`helm repo add`), `-u -r` is the only mode that works. That is a helm limitation rather than a new one: `helm dependency build` refuses an unregistered repository outright, and `update --skip-refresh` cannot reach it either.

# Additional Information

Supercedes https://github.com/aneoconsulting/ArmoniK.Infra/pull/292

Behaviour of helm 3.18.4 that the modes are built around, reproduced with an isolated `HELM_REPOSITORY_CONFIG`:

| | repository in `helm repo list` | repository only declared in `Chart.yaml` |
| --- | --- | --- |
| `build --skip-refresh` | works off the cached index | `Error: no repository definition for <url>` |
| `build` | works | same error, refreshing does not help |
| `update --skip-refresh` | works off the cached index | `Error: no cached repository for helm-manager-<sha>` |
| `update` | works | works, via "Getting updates for unmanaged Helm repositories" |

When `-u` is needed after changing a local (`file://`) chart, reproduced the same way against a parent using the same `0.1.x`-style constraint as ours:

| what changed | bare run | `-u` |
| --- | --- | --- |
| the chart's content (templates, values, helpers) | re-packages it, the vendored `.tgz` picks the edit up | not needed |
| its `version:`, 0.1.0 -> 0.1.1, still inside the declared `0.1.x` | `Error: can't get a valid version for dependency <name>` | resolves it, rewrites `Chart.lock` |
| the dependent's dependency entry (added, removed, re-constrained) | `Error: the lock file (Chart.lock) is out of sync with the dependencies file (Chart.yaml)` | resolves it, rewrites `Chart.lock` |

A version bump fails the bare run even though the range still matches it, because `build` does not re-resolve the range: it reproduces the exact version `Chart.lock` pins. And when the bump leaves the constraint altogether (0.1.0 -> 0.2.0 against `0.1.x`), `-u` fails too and names the constraint, so the dependent `Chart.yaml` files have to be bumped first: `armonik-common` alone is a dependency of the three plane charts and of the umbrella.

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.

