### PR TITLE
feat: handle GCS and Pub/Sub

### DIFF
--- a/charts/armonik-compute-plane/Chart.yaml
+++ b/charts/armonik-compute-plane/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.37.1
+appVersion: 0.40.1
 version: 0.1.0
 name: armonik-compute-plane
 description: A Helm chart for ArmoniK

--- a/charts/armonik-control-plane/Chart.yaml
+++ b/charts/armonik-control-plane/Chart.yaml
@@ -1,5 +1,5 @@
 apiVersion: v2
-appVersion: 0.37.1
+appVersion: 0.40.1
 version: 0.1.0
 name: armonik-control-plane
 description: A Helm chart for ArmoniK

--- a/charts/armonik-dependencies/Chart.lock
+++ b/charts/armonik-dependencies/Chart.lock
@@ -16,9 +16,9 @@ dependencies:
   version: 8.15.0
 - name: fluent-bit
   repository: https://fluent.github.io/helm-charts
-  version: 0.57.9
+  version: 0.58.1
 - name: seq
   repository: https://helm.datalust.co
   version: 2024.3.2
-digest: sha256:bc1987489212995dacb7cea82c3d32e6ff2c435d443b85274bcf0a49bdd6891c
-generated: "2026-07-24T16:40:07.316528822+02:00"
+digest: sha256:4029712459ff7c25055c0f13f5f53d1b5680bcdcf4998723c4eae288dd94306b
+generated: "2026-08-24T17:12:58.112324782+02:00"

--- a/charts/armonik-operators/Chart.lock
+++ b/charts/armonik-operators/Chart.lock
@@ -7,7 +7,7 @@ dependencies:
   version: 2.20.2
 - name: external-secrets
   repository: https://charts.external-secrets.io
-  version: 2.8.0
+  version: 2.9.0
 - name: cert-manager
   repository: https://charts.jetstack.io
   version: v1.21.1
@@ -17,5 +17,5 @@ dependencies:
 - name: kube-prometheus-stack
   repository: https://prometheus-community.github.io/helm-charts
   version: 82.18.0
-digest: sha256:c520ab9be6f51a8e767546f436e6883785703e0e6d7b21ffabc4a99499500985
-generated: "2026-07-31T17:57:56.896981758+02:00"
+digest: sha256:181107d629a9cf6d5b691bc0d15cf9b4e6dfe9ba3afa58b8a99fd7a2ff2f7535
+generated: "2026-08-11T17:24:56.161359231+02:00"

--- a/charts/armonik/templates/conf/_core.tpl
+++ b/charts/armonik/templates/conf/_core.tpl
@@ -8,6 +8,7 @@
         (include "armonik.rabbitmq.conf" . | fromYaml)
         (include "armonik.redis.conf" . | fromYaml)
         (include "armonik.gcs.conf" . | fromYaml)
+        (include "armonik.pubsub.conf" . | fromYaml)
         (include "armonik.conf.coreHelper" . | fromYaml)
         (list .Values "conf" "core" | include "armonik.utils.index" | fromYaml)
       | include "armonik.conf.merge" -}}

--- a/charts/armonik/templates/conf/_core.tpl
+++ b/charts/armonik/templates/conf/_core.tpl
@@ -7,6 +7,7 @@
         (include "armonik.activemq.conf" . | fromYaml)
         (include "armonik.rabbitmq.conf" . | fromYaml)
         (include "armonik.redis.conf" . | fromYaml)
+        (include "armonik.gcs.conf" . | fromYaml)
         (include "armonik.conf.coreHelper" . | fromYaml)
         (list .Values "conf" "core" | include "armonik.utils.index" | fromYaml)
       | include "armonik.conf.merge" -}}

--- a/charts/armonik/templates/storage/_gcs.tpl
+++ b/charts/armonik/templates/storage/_gcs.tpl
@@ -3,13 +3,14 @@ Configuration for GCS forwarded to ArmoniK Core.
 This configuration is used to configure the GCS object storage adapter.
 */}}
 {{- define "armonik.gcs.conf" -}}
-{{- if .Values.gcs.enabled }}
+{{- $gcs := list .Values "dependencies" "gcs" | include "armonik.utils.index" | fromYaml | default dict -}}
+{{- if $gcs.enabled }}
 env:
   Components__ObjectStorageAdaptorSettings__ClassName: "ArmoniK.Core.Adapters.Gcs.ObjectBuilder"
   Components__ObjectStorageAdaptorSettings__AdapterAbsolutePath: "/adapters/object/gcs/ArmoniK.Core.Adapters.Gcs.dll"
-  Gcs__ProjectId: {{ .Values.gcs.projectId | quote }}
-  Gcs__BucketName: {{ .Values.gcs.bucketName | quote }}
-  Gcs__CredentialsFilePath: {{ .Values.gcs.credentialsFilePath | quote }}
-  Gcs__EmulatorEndpoint: {{ .Values.gcs.emulatorEndpoint | quote }}
+  Gcs__ProjectId: {{ $gcs.projectId | quote }}
+  Gcs__BucketName: {{ $gcs.bucketName | quote }}
+  Gcs__CredentialsFilePath: {{ $gcs.credentialsFilePath | quote }}
+  Gcs__EmulatorEndpoint: {{ $gcs.emulatorEndpoint | quote }}
 {{- end }}
 {{- end }}

--- a/charts/armonik/templates/storage/_gcs.tpl
+++ b/charts/armonik/templates/storage/_gcs.tpl
@@ -3,7 +3,7 @@ Configuration for GCS forwarded to ArmoniK Core.
 This configuration is used to configure the GCS object storage adapter.
 */}}
 {{- define "armonik.gcs.conf" -}}
-{{- $gcs := list .Values "dependencies" "gcs" | include "armonik.utils.index" | fromYaml | default dict -}}
+{{- $gcs := list .Values "dependencies" "gcs" | include "armonik.utils.index" | fromYaml -}}
 {{- if $gcs.enabled }}
 env:
   Components__ObjectStorageAdaptorSettings__ClassName: "ArmoniK.Core.Adapters.Gcs.ObjectBuilder"

--- a/charts/armonik/templates/storage/_gcs.tpl
+++ b/charts/armonik/templates/storage/_gcs.tpl
@@ -1,0 +1,11 @@
+{{- define "armonik.gcs.conf" -}}
+{{- if .Values.gcs.enabled }}
+env:
+  Components__ObjectStorageAdaptorSettings__ClassName: "ArmoniK.Core.Adapters.Gcs.ObjectBuilder"
+  Components__ObjectStorageAdaptorSettings__AdapterAbsolutePath: "/adapters/object/gcs/ArmoniK.Core.Adapters.Gcs.dll"
+  Gcs__ProjectId: {{ .Values.gcs.projectId | quote }}
+  Gcs__BucketName: {{ .Values.gcs.bucketName | quote }}
+  Gcs__CredentialsFilePath: {{ .Values.gcs.credentialsFilePath | quote }}
+  Gcs__EmulatorEndpoint: {{ .Values.gcs.emulatorEndpoint | quote }}
+{{- end }}
+{{- end }}

--- a/charts/armonik/templates/storage/_gcs.tpl
+++ b/charts/armonik/templates/storage/_gcs.tpl
@@ -1,3 +1,7 @@
+{{/*
+Configuration for GCS forwarded to ArmoniK Core.
+This configuration is used to configure the GCS object storage adapter.
+*/}}
 {{- define "armonik.gcs.conf" -}}
 {{- if .Values.gcs.enabled }}
 env:

--- a/charts/armonik/templates/storage/_pubsub.tpl
+++ b/charts/armonik/templates/storage/_pubsub.tpl
@@ -3,7 +3,7 @@ Configuration for Pub/Sub forwarded to ArmoniK Core.
 This configuration is used to configure the Pub/Sub queue adapter.
 */}}
 {{- define "armonik.pubsub.conf" -}}
-{{- $pubsub := list .Values "dependencies" "pubsub" | include "armonik.utils.index" | fromYaml | default dict -}}
+{{- $pubsub := list .Values "dependencies" "pubsub" | include "armonik.utils.index" | fromYaml -}}
 {{- if $pubsub.enabled }}
 env:
   Components__QueueAdaptorSettings__ClassName: "ArmoniK.Core.Adapters.PubSub.QueueBuilder"

--- a/charts/armonik/templates/storage/pubsub.tpl
+++ b/charts/armonik/templates/storage/pubsub.tpl
@@ -3,12 +3,13 @@ Configuration for Pub/Sub forwarded to ArmoniK Core.
 This configuration is used to configure the Pub/Sub queue adapter.
 */}}
 {{- define "armonik.pubsub.conf" -}}
-{{- if .Values.pubsub.enabled }}
+{{- $pubsub := list .Values "dependencies" "pubsub" | include "armonik.utils.index" | fromYaml | default dict -}}
+{{- if $pubsub.enabled }}
 env:
   Components__QueueAdaptorSettings__ClassName: "ArmoniK.Core.Adapters.PubSub.QueueBuilder"
   Components__QueueAdaptorSettings__AdapterAbsolutePath: "/adapters/queue/pubsub/ArmoniK.Core.Adapters.PubSub.dll"
-  PubSub__ProjectId: {{ .Values.pubsub.projectId | quote }}
-  PubSub__KmsKeyName: {{ .Values.pubsub.kmsKeyName | quote }}
-  PubSub__Prefix: {{ .Values.pubsub.prefix | quote }}
+  PubSub__ProjectId: {{ $pubsub.projectId | quote }}
+  PubSub__KmsKeyName: {{ $pubsub.kmsKeyName | quote }}
+  PubSub__Prefix: {{ $pubsub.prefix | quote }}
 {{- end }}
 {{- end }}

--- a/charts/armonik/templates/storage/pubsub.tpl
+++ b/charts/armonik/templates/storage/pubsub.tpl
@@ -1,0 +1,14 @@
+{{/*
+Configuration for Pub/Sub forwarded to ArmoniK Core.
+This configuration is used to configure the Pub/Sub queue adapter.
+*/}}
+{{- define "armonik.pubsub.conf" -}}
+{{- if .Values.pubsub.enabled }}
+env:
+  Components__QueueAdaptorSettings__ClassName: "ArmoniK.Core.Adapters.PubSub.QueueBuilder"
+  Components__QueueAdaptorSettings__AdapterAbsolutePath: "/adapters/queue/pubsub/ArmoniK.Core.Adapters.PubSub.dll"
+  PubSub__ProjectId: {{ .Values.pubsub.projectId | quote }}
+  PubSub__KmsKeyName: {{ .Values.pubsub.kmsKeyName | quote }}
+  PubSub__Prefix: {{ .Values.pubsub.prefix | quote }}
+{{- end }}
+{{- end }}

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -92,23 +92,6 @@ conf:
   log:
     minimumLevel: Information
 
-gcs:
-  enabled: false
-  projectId: ""
-  bucketName: ""
-  emulatorEndpoint: ""
-  credentialsFilePath: ""
-  # degreeOfParallelism: 0
-  # chunkDownloadSize: 2097152
-  # maxRetry: 5
-  # msAfterRetry: 500
-
-pubsub:
-  enabled: false
-  projectId: ""
-  prefix: ""
-  kmsKeyName: ""
-
 ################## INGRESS ##################
 ingress:
   enabled: true
@@ -613,3 +596,18 @@ dependencies:
   # Its broken static additionalScrapeConfigs Secret is now first-party ServiceMonitor/PodMonitor.
   # external-secrets moved to charts/armonik-operators.
 ############################################
+
+  ################## GCS ##################
+  gcs:
+    enabled: false
+    projectId: "" # required when gcs.enabled
+    bucketName: "" # required when gcs.enabled
+    emulatorEndpoint: ""
+    credentialsFilePath: ""
+
+  ################## PUBSUB ##################
+  pubsub:
+    enabled: false
+    projectId: "" # required when pubsub.enabled
+    prefix: ""
+    kmsKeyName: ""

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -92,6 +92,17 @@ conf:
   log:
     minimumLevel: Information
 
+gcs:
+  enabled: false
+  projectId: ""
+  bucketName: ""
+  emulatorEndpoint: ""
+  credentialsFilePath: ""
+  # degreeOfParallelism: 0
+  # chunkDownloadSize: 2097152
+  # maxRetry: 5
+  # msAfterRetry: 500
+
 ################## INGRESS ##################
 ingress:
   enabled: true

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -600,14 +600,14 @@ dependencies:
   ################## GCS ##################
   gcs:
     enabled: false
-    projectId: "" # required when gcs.enabled
-    bucketName: "" # required when gcs.enabled
+    projectId: ""  # required when gcs.enabled
+    bucketName: ""  # required when gcs.enabled
     emulatorEndpoint: ""
     credentialsFilePath: ""
 
   ################## PUBSUB ##################
   pubsub:
     enabled: false
-    projectId: "" # required when pubsub.enabled
+    projectId: ""  # required when pubsub.enabled
     prefix: ""
     kmsKeyName: ""

--- a/charts/armonik/values.yaml
+++ b/charts/armonik/values.yaml
@@ -3,7 +3,7 @@
 ############################################
 global:
   version:
-    armonikCore: "0.37.1"  ### TODO FIX VERSIONS GLOBAL IF NULL USE DEFAULT IN SUB CHARTS COMPUTE-PLANE
+    armonikCore: "0.40.1"  ### TODO FIX VERSIONS GLOBAL IF NULL USE DEFAULT IN SUB CHARTS COMPUTE-PLANE
     # armonikPollingagent: "0.35.0"
     # armonikGui: "0.14.5"
     # nginx: "1.27.4-alpine-slim"
@@ -102,6 +102,12 @@ gcs:
   # chunkDownloadSize: 2097152
   # maxRetry: 5
   # msAfterRetry: 500
+
+pubsub:
+  enabled: false
+  projectId: ""
+  prefix: ""
+  kmsKeyName: ""
 
 ################## INGRESS ##################
 ingress:


### PR DESCRIPTION
# Motivation

Add Helm chart support for configuring and enabling GCS and Pub/Sub

# Description

Handling for GCS and Pub/Sub has been added to the Helm charts, allowing both components to be enabled and configured through Helm values.

# Testing

The changes have been tested through Helm installations and upgrades with different combinations of GCS and Pub/Sub enabled/disabled.

In particular:

Initial installation with both GCS and Pub/Sub enabled works as expected.
Pub/Sub topics and subscriptions are created for each partition.
Upgrade scenarios with false → true have also been tested.

Some behaviours observed during upgrades, especially for GCS and the first job after enabling Pub/Sub, still require further investigation and are documented separately.

# Impact

[Discuss the impact of your modifications on ArmoniK. This might include effects on performance, configuration, documentation, new dependencies, or changes in behaviour.]

# Additional Information

[Any additional information that reviewers should be aware of.]

# Checklist

- [x] My code adheres to the coding and style guidelines of the project.
- [x] I have performed a self-review of my code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have made corresponding changes to the documentation.
- [x] I have thoroughly tested my modifications and added tests when necessary.
- [x] Tests pass locally and in the CI.
- [x] I have assessed the performance impact of my modifications.